### PR TITLE
fix(events): support hierarchical JSON schemas

### DIFF
--- a/packages/cli/src/commands/__tests__/db-diff.test.ts
+++ b/packages/cli/src/commands/__tests__/db-diff.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { clearCache, setConfig } from '@happyvertical/smrt-config';
 import { ObjectRegistry } from '@happyvertical/smrt-core';
+import { SchemaComparer } from '@happyvertical/smrt-core/migrations';
 import { getDatabase } from '@happyvertical/sql';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -271,6 +272,49 @@ describe('db:diff (real SQLite + real SchemaComparer)', () => {
     const out = output();
     expect(out).toContain('Type');
     expect(out).toContain('widgets.status');
+  });
+
+  it('reports disabled foreign-key drift whose live constraint name is unavailable', async () => {
+    declareSchema({
+      children: {
+        tableName: 'children',
+        columns: { id: { type: 'TEXT', primaryKey: true } },
+        indexes: [],
+      },
+    });
+    vi.spyOn(SchemaComparer.prototype, 'compare').mockResolvedValue({
+      has_changes: true,
+      added_tables: [],
+      dropped_tables: [],
+      orphan_tables: [],
+      changes: [
+        {
+          type: 'drop_foreign_key',
+          table: 'children',
+          name: 'children_parent_id_parents_id_fkey',
+          foreignKey: {
+            column: 'parent_id',
+            referencesTable: 'parents',
+            referencesColumn: 'id',
+          },
+          advisory: {
+            severity: 'warning',
+            message:
+              '@happyvertical/sql schema introspection does not expose the live PostgreSQL constraint name. Drop the live constraint deliberately, then rerun.',
+          },
+        },
+      ],
+    } as never);
+
+    await dbDiffCommand.handler([], {});
+
+    const out = output();
+    expect(out).toContain('Foreign-key drift needing a manual step (1)');
+    expect(out).toContain('children: remove constraint');
+    expect(out).toContain(
+      'does not expose the live PostgreSQL constraint name',
+    );
+    expect(out).not.toContain('no migrations needed');
   });
 
   it('lists orphan indexes to drop when --drop-indexes is set', async () => {

--- a/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
+++ b/packages/cli/src/commands/__tests__/db-migrate-actions.test.ts
@@ -319,6 +319,42 @@ describe('partitionSchemaChanges', () => {
       /^add_foreign_key_children_[a-f0-9]{8}$/,
     );
   });
+
+  it('keeps disabled foreign-key removals manual when no exact drop SQL exists', () => {
+    const advisory = {
+      severity: 'warning' as const,
+      message:
+        '@happyvertical/sql schema introspection does not expose the live PostgreSQL constraint name. Drop it deliberately, then rerun.',
+    };
+    const result = partitionSchemaChanges(
+      [
+        {
+          type: 'drop_foreign_key',
+          table: 'children',
+          name: 'children_parent_id_parents_id_fkey',
+          advisory,
+        },
+      ],
+      () => 'Child',
+    );
+
+    expect(result.migrations).toEqual([]);
+    expect(result.manualInterventions).toEqual([
+      expect.objectContaining({
+        type: 'drop_foreign_key',
+        tableName: 'children',
+        className: 'Child',
+        advisory,
+      }),
+    ]);
+    expect(
+      getSyntheticMigrationNameForChange({
+        type: 'drop_foreign_key',
+        table: 'children',
+        sql: 'ALTER TABLE "children" DROP CONSTRAINT "legacy_parent_fk"',
+      }),
+    ).toMatch(/^drop_foreign_key_children_[a-f0-9]{8}$/);
+  });
 });
 
 describe('shouldFailDbMigrate', () => {

--- a/packages/cli/src/commands/__tests__/db-status.test.ts
+++ b/packages/cli/src/commands/__tests__/db-status.test.ts
@@ -149,6 +149,32 @@ describe('db:status', () => {
               actual: 'INTEGER',
             },
           },
+          {
+            type: 'add_foreign_key',
+            table: 'contents',
+            name: 'contents_author_id_users_id_fkey',
+            foreignKey: {
+              column: 'author_id',
+              referencesTable: 'users',
+              referencesColumn: 'id',
+            },
+            sqlStatements: ['ALTER TABLE contents ADD CONSTRAINT ...'],
+          },
+          {
+            type: 'drop_foreign_key',
+            table: 'contents',
+            name: 'contents_legacy_id_legacy_id_fkey',
+            foreignKey: {
+              column: 'legacy_id',
+              referencesTable: 'legacy',
+              referencesColumn: 'id',
+            },
+            advisory: {
+              severity: 'warning',
+              message:
+                'Exact live constraint-name introspection is unavailable; remove it deliberately, then rerun.',
+            },
+          },
         ],
       }),
     ).toEqual([
@@ -175,6 +201,18 @@ describe('db:status', () => {
         type: 'type_mismatch',
         recommendation:
           'Manual intervention required: expected TEXT, found INTEGER.',
+      },
+      {
+        name: 'contents.author_id -> users.id',
+        type: 'missing_foreign_key',
+        recommendation:
+          'Run `smrt db:migrate` to add the missing foreign key and reconcile the live schema.',
+      },
+      {
+        name: 'contents.legacy_id -> legacy.id',
+        type: 'disabled_foreign_key',
+        recommendation:
+          'Exact live constraint-name introspection is unavailable; remove it deliberately, then rerun.',
       },
     ]);
   });
@@ -318,6 +356,86 @@ describe('db:status', () => {
       other: [],
     });
     expect(closeMock).toHaveBeenCalledOnce();
+  });
+
+  it('reports advisory foreign-key removal drift in human status', async () => {
+    compareMock.mockResolvedValue({
+      added_tables: [],
+      dropped_tables: [],
+      has_changes: true,
+      changes: [
+        {
+          type: 'drop_foreign_key',
+          table: 'events',
+          name: 'events_parent_id_events_id_fkey',
+          foreignKey: {
+            column: 'parent_id',
+            referencesTable: 'events',
+            referencesColumn: 'id',
+          },
+          advisory: {
+            severity: 'warning',
+            message:
+              '@happyvertical/sql schema introspection does not expose the live PostgreSQL constraint name. Drop the live constraint deliberately, then rerun.',
+          },
+        },
+      ],
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await dbStatusCommand.handler([], { verbose: true });
+
+    const output = logSpy.mock.calls.map((call) => call.join('')).join('\n');
+    expect(output).toContain('Drift Detected');
+    expect(output).toContain(
+      'events.parent_id -> events.id: disabled_foreign_key',
+    );
+    expect(output).toContain(
+      'does not expose the live PostgreSQL constraint name',
+    );
+    expect(output).not.toContain('Live schema matches current manifests');
+  });
+
+  it('reports advisory foreign-key removal drift in JSON status', async () => {
+    compareMock.mockResolvedValue({
+      added_tables: [],
+      dropped_tables: [],
+      has_changes: true,
+      changes: [
+        {
+          type: 'drop_foreign_key',
+          table: 'events',
+          name: 'events_parent_id_events_id_fkey',
+          foreignKey: {
+            column: 'parent_id',
+            referencesTable: 'events',
+            referencesColumn: 'id',
+          },
+          advisory: {
+            severity: 'warning',
+            message:
+              '@happyvertical/sql schema introspection does not expose the live PostgreSQL constraint name. Drop the live constraint deliberately, then rerun.',
+          },
+        },
+      ],
+    });
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await dbStatusCommand.handler([], { json: true });
+
+    const parsed = JSON.parse(
+      logSpy.mock.calls.map((call) => call.join('')).join('\n'),
+    );
+    expect(parsed.drift).toEqual([
+      {
+        name: 'events.parent_id -> events.id',
+        type: 'disabled_foreign_key',
+        recommendation:
+          '@happyvertical/sql schema introspection does not expose the live PostgreSQL constraint name. Drop the live constraint deliberately, then rerun.',
+      },
+    ]);
   });
 
   it('includes tenant id compatibility precondition failures in JSON status', async () => {

--- a/packages/cli/src/commands/__tests__/utilities-handlers.test.ts
+++ b/packages/cli/src/commands/__tests__/utilities-handlers.test.ts
@@ -1110,6 +1110,36 @@ describe('utility command handlers', () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it('db:migrate reports a disabled foreign key whose live name is unavailable', async () => {
+    configureMigrate();
+    schemaCompare.mockResolvedValue({
+      added_tables: [],
+      changes: [
+        {
+          type: 'drop_foreign_key',
+          table: 'children',
+          name: 'children_parent_id_parents_id_fkey',
+          advisory: {
+            severity: 'warning',
+            message:
+              '@happyvertical/sql schema introspection does not expose the live PostgreSQL constraint name. Drop the live constraint deliberately, then rerun.',
+          },
+        },
+      ],
+    });
+
+    await utilityCommands['db:migrate'].handler([], {});
+
+    const out = logged();
+    expect(out).toContain('requires manual intervention');
+    expect(out).toContain('children');
+    expect(out).toContain(
+      'does not expose the live PostgreSQL constraint name',
+    );
+    expect(out).not.toContain('Successfully applied');
+    expect(process.exitCode).toBe(1);
+  });
+
   it('db:migrate verbose lists STI child tables', async () => {
     configureMigrate();
     registry.getInitializationOrder.mockReturnValue(['Article', 'Page']);

--- a/packages/cli/src/commands/db-diff.ts
+++ b/packages/cli/src/commands/db-diff.ts
@@ -237,9 +237,14 @@ export const dbDiffCommand: CLICommand = {
       // Report-only findings (#2369) are printed even when nothing is
       // executable so an orphan NOT NULL column is never hidden behind an
       // "up to date" line.
-      const { advisories } = partitionSchemaChanges(
+      const { advisories, manualInterventions } = partitionSchemaChanges(
         diff.changes as SchemaChangeLike[],
         (tableName) => tableName,
+      );
+      const manualForeignKeyChanges = manualInterventions.filter(
+        (change) =>
+          change.type === 'add_foreign_key' ||
+          change.type === 'drop_foreign_key',
       );
 
       if (!diff.has_changes) {
@@ -258,6 +263,7 @@ export const dbDiffCommand: CLICommand = {
       );
       if (
         executableOrManual.length === 0 &&
+        manualForeignKeyChanges.length === 0 &&
         diff.added_tables.length === 0 &&
         diff.dropped_tables.length === 0
       ) {
@@ -420,6 +426,24 @@ export const dbDiffCommand: CLICommand = {
           );
         }
         console.log('     (Type changes require manual migration)\n');
+      }
+
+      if (manualForeignKeyChanges.length > 0) {
+        console.log(
+          `  ⚠️  Foreign-key drift needing a manual step (${manualForeignKeyChanges.length}):`,
+        );
+        for (const change of manualForeignKeyChanges) {
+          const operation =
+            change.type === 'drop_foreign_key' ? 'remove' : 'add';
+          console.log(`     ! ${change.tableName}: ${operation} constraint`);
+          console.log(
+            `       ${change.advisory?.message ?? 'foreign-key constraint requires manual repair'}`,
+          );
+          for (const sql of change.advisory?.suggestedSql ?? []) {
+            console.log(`       ↳ ${sql}`);
+          }
+        }
+        console.log();
       }
 
       printSchemaAdvisories(advisories, {

--- a/packages/cli/src/commands/db-migrate-actions.ts
+++ b/packages/cli/src/commands/db-migrate-actions.ts
@@ -26,6 +26,7 @@ export interface MigrationAction {
     | 'drop_column'
     | 'alter_column'
     | 'add_foreign_key'
+    | 'drop_foreign_key'
     | 'add_index'
     | 'drop_index'
     | 'type_mismatch'
@@ -92,6 +93,7 @@ export interface SchemaChangeLike {
     | 'alter_column'
     | 'orphan_column'
     | 'add_foreign_key'
+    | 'drop_foreign_key'
     | 'add_index'
     | 'drop_index'
     | 'orphan_index'
@@ -316,6 +318,13 @@ export function getSyntheticMigrationNameForAction(
         : null;
     }
 
+    case 'drop_foreign_key': {
+      const fingerprint = sqlShapeFingerprint(action);
+      return fingerprint
+        ? `drop_foreign_key_${action.tableName}_${fingerprint}`
+        : null;
+    }
+
     case 'drop_index': {
       if (!action.indexName) return null;
       const fingerprint = sqlShapeFingerprint(action);
@@ -376,6 +385,13 @@ export function getSyntheticMigrationNameForChange(
       const fingerprint = sqlShapeFingerprint(change);
       return fingerprint
         ? `add_foreign_key_${change.table}_${fingerprint}`
+        : null;
+    }
+
+    case 'drop_foreign_key': {
+      const fingerprint = sqlShapeFingerprint(change);
+      return fingerprint
+        ? `drop_foreign_key_${change.table}_${fingerprint}`
         : null;
     }
 
@@ -453,6 +469,7 @@ export function classifyFailedMigration(
     !migrationName.startsWith('drop_column_') &&
     !migrationName.startsWith('alter_column_') &&
     !migrationName.startsWith('add_foreign_key_') &&
+    !migrationName.startsWith('drop_foreign_key_') &&
     !migrationName.startsWith('add_index_') &&
     !migrationName.startsWith('drop_index_') &&
     !migrationName.startsWith('type_upgrade_')
@@ -476,6 +493,7 @@ export function getUnresolvedGeneratedMigrationNames(
       change.type !== 'drop_column' &&
       change.type !== 'alter_column' &&
       change.type !== 'add_foreign_key' &&
+      change.type !== 'drop_foreign_key' &&
       change.type !== 'add_index' &&
       change.type !== 'drop_index' &&
       change.type !== 'type_upgrade'
@@ -709,9 +727,10 @@ export function partitionSchemaChanges(
         break;
       }
 
-      case 'add_foreign_key': {
+      case 'add_foreign_key':
+      case 'drop_foreign_key': {
         const action: MigrationAction = {
-          type: 'add_foreign_key',
+          type: change.type,
           tableName: change.table,
           className,
           sql: change.sql,

--- a/packages/cli/src/commands/db-status.ts
+++ b/packages/cli/src/commands/db-status.ts
@@ -231,6 +231,11 @@ export function summarizeSchemaDiff(diff: {
       actual: string;
     };
     alteration?: string;
+    foreignKey?: {
+      column: string;
+      referencesTable: string;
+      referencesColumn: string;
+    };
     advisory?: { severity: 'warning' | 'info'; message: string };
     sql?: string;
     sqlStatements?: string[];
@@ -266,6 +271,24 @@ export function summarizeSchemaDiff(diff: {
             'Run `smrt db:migrate` to add the missing index and reconcile the live schema.',
         });
         break;
+
+      case 'add_foreign_key':
+      case 'drop_foreign_key': {
+        const relationship = change.foreignKey
+          ? `${change.table}.${change.foreignKey.column} -> ${change.foreignKey.referencesTable}.${change.foreignKey.referencesColumn}`
+          : `${change.table}.${change.name ?? '(unknown)'}`;
+        const isAddition = change.type === 'add_foreign_key';
+        drift.push({
+          name: relationship,
+          type: isAddition ? 'missing_foreign_key' : 'disabled_foreign_key',
+          recommendation:
+            change.advisory?.message ??
+            (isAddition
+              ? 'Run `smrt db:migrate` to add the missing foreign key and reconcile the live schema.'
+              : 'Run `smrt db:migrate` to remove the disabled foreign key and reconcile the live schema.'),
+        });
+        break;
+      }
 
       case 'type_upgrade':
         switch (classifyTypeUpgradeSql(change.sql)) {

--- a/packages/cli/src/commands/utilities.ts
+++ b/packages/cli/src/commands/utilities.ts
@@ -1770,7 +1770,10 @@ export default testManifest;
             '⚠️  Schema drift detected that requires manual intervention:\n',
           );
           for (const change of manualInterventions) {
-            if (change.type === 'add_foreign_key') {
+            if (
+              change.type === 'add_foreign_key' ||
+              change.type === 'drop_foreign_key'
+            ) {
               console.log(
                 `   ${change.tableName}: ${change.advisory?.message ?? change.sql?.replace(/^--\s*/, '') ?? 'foreign-key constraint requires manual repair'}`,
               );
@@ -1859,6 +1862,9 @@ export default testManifest;
             const foreignKeyMigrations = migrations.filter(
               (m) => m.type === 'add_foreign_key',
             );
+            const foreignKeyDrops = migrations.filter(
+              (m) => m.type === 'drop_foreign_key',
+            );
             const indexDrops = migrations.filter(
               (m) => m.type === 'drop_index',
             );
@@ -1924,6 +1930,16 @@ export default testManifest;
                 `  🔗 Foreign-key constraints to add: ${foreignKeyMigrations.length}`,
               );
               for (const m of foreignKeyMigrations) {
+                console.log(`     ${m.tableName}`);
+              }
+              console.log();
+            }
+
+            if (foreignKeyDrops.length > 0) {
+              console.log(
+                `  🔗 Foreign-key constraints to drop: ${foreignKeyDrops.length}`,
+              );
+              for (const m of foreignKeyDrops) {
                 console.log(`     ${m.tableName}`);
               }
               console.log();
@@ -2062,6 +2078,9 @@ export default testManifest;
             } else if (migration.type === 'add_foreign_key') {
               migrationSql = migration.sql || '';
               actionDesc = `Added foreign-key constraint on ${migration.tableName}`;
+            } else if (migration.type === 'drop_foreign_key') {
+              migrationSql = migration.sql || '';
+              actionDesc = `Dropped foreign-key constraint on ${migration.tableName}`;
             } else {
               continue;
             }
@@ -2084,7 +2103,9 @@ export default testManifest;
                           ? `Drop index ${migration.indexName} on ${migration.tableName}`
                           : migration.type === 'add_foreign_key'
                             ? `Add foreign-key constraint on ${migration.tableName}`
-                            : `Add index ${migration.index?.name} on ${migration.tableName}`,
+                            : migration.type === 'drop_foreign_key'
+                              ? `Drop foreign-key constraint on ${migration.tableName}`
+                              : `Add index ${migration.index?.name} on ${migration.tableName}`,
               version: '1.0.0',
               // Auto-migrations don't carry a DOWN script. Atomic execution
               // rolls back the surrounding transaction instead of relying on

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -222,12 +222,21 @@ app-side cascade/preflight action so the stored identifier survives deletion;
 document the retention reason at the field, and keep ordinary same-package
 relationships constrained.
 
+When a relationship is valid on every engine but a particular database cannot
+faithfully enforce its physical shape, use the public, explicit allowlist
+`@foreignKey(Target, { constraint: { engines: ['postgres', 'sqlite'] } })`.
+Only physical DDL and schema dependency planning are engine-scoped; native UUID
+storage, relationship loading, indexes, and application-side delete enforcement
+remain active on every engine. Empty or unknown allowlists fail closed. Do not
+use this option to hide an otherwise invalid schema.
+
 - Change column/index emission on every shipping path, proven by the path-parity
   test `src/schema/schema-path-parity.test.ts` (#2359; index rules in the module doc). A "same as migrations" comment is a claim to check.
 - Every new query predicate ships with its index, or a reason it doesn't.
 - Creation is dependency-planned on every entry point. PostgreSQL defers mutual
   cycle constraints until both tables exist; SQLite keeps cycles inline;
-  DuckDB refuses unsupported cycles/actions rather than silently omitting them.
+  DuckDB refuses unsupported cycles/actions unless the field has an explicit
+  physical-constraint engine allowlist rather than silently omitting them.
   In particular, generated same-package constraints retain the compatibility
   default `ON UPDATE CASCADE`; DuckDB/JSON cannot enforce that action and must
   return an actionable refusal instead of stripping the clause.

--- a/packages/core/agents/schema-paths.md
+++ b/packages/core/agents/schema-paths.md
@@ -685,6 +685,14 @@ and indexes but deliberately emits no physical constraint, avoiding circular
 package DDL. Tenant markers follow the same non-constraint rule because a
 tenant is a scope, not an ownership edge.
 
+For a same-package relationship whose semantics are portable but whose physical
+constraint shape is not, `@foreignKey(Target, { constraint: { engines: [...] } })`
+is the public exception. The allowlist scopes physical DDL and dependency
+planning only. Relationship metadata, UUID representation, derived indexes, and
+the application delete rail remain canonical on every engine. Empty or unknown
+engine lists fail closed; unannotated unsupported DuckDB cycles and actions keep
+their actionable refusal.
+
 Every schema creation entry point uses the same deterministic dependency
 planner. Parents are created before children. SQLite keeps cycle constraints
 inline because it can create them safely. PostgreSQL creates mutually dependent

--- a/packages/core/src/decorators/index.ts
+++ b/packages/core/src/decorators/index.ts
@@ -213,7 +213,19 @@ export interface RelationshipFieldOptions extends FieldOptions {
    * after the parent is deleted. Ordinary same-package relationships must leave
    * this enabled (the default).
    */
-  constraint?: boolean;
+  constraint?:
+    | boolean
+    | {
+        /**
+         * Database engines on which SMRT emits the physical constraint.
+         *
+         * Relationship loading, UUID storage, indexes, and application-side
+         * delete enforcement remain active on every engine. Use this narrow
+         * allowlist only when an engine cannot faithfully enforce a supported
+         * relationship shape (for example a DuckDB self-reference).
+         */
+        engines: Array<'postgres' | 'sqlite' | 'duckdb' | 'json'>;
+      };
 }
 
 /**
@@ -442,6 +454,13 @@ export function field(
  *   // Declared later in this module — name string, never evaluated
  *   @foreignKey('Invoice')
  *   invoiceId: string = '';
+ *
+ *   // Physical constraint only where the engine can enforce this shape;
+ *   // relationship loading and app-side delete policy remain cross-engine.
+ *   @foreignKey('Order', {
+ *     constraint: { engines: ['postgres', 'sqlite'] },
+ *   })
+ *   hierarchyParentId: string | null = null;
  * }
  *
  * // Cross-package: runtime relationship, index, and loading; no physical FK

--- a/packages/core/src/migrations/differ.ts
+++ b/packages/core/src/migrations/differ.ts
@@ -10,9 +10,11 @@ import { detectEngine, getDDLStrategy } from '../schema/ddl/index.js';
 import type { DatabaseEngine } from '../schema/ddl/types.js';
 import {
   foreignKeyConstraintName,
+  foreignKeyRelationshipKey,
   renderForeignKeyConstraint,
   renderForeignKeyOrphanDetector,
   renderForeignKeyOrphanRepair,
+  schemaForeignKeys,
   schemaForeignKeysForEngine,
 } from '../schema/foreign-key-ddl.js';
 import {
@@ -574,10 +576,52 @@ export class SchemaComparer {
   ): Promise<SchemaChange[]> {
     const changes: SchemaChange[] = [];
     const liveForeignKeys = dbSchema.foreignKeys || [];
-    for (const foreignKey of schemaForeignKeysForEngine(
+    const declaredForeignKeys = schemaForeignKeys(manifest);
+    const enabledForeignKeys = schemaForeignKeysForEngine(
       manifest,
       this.engine,
-    )) {
+    );
+    const enabledKeys = new Set(
+      enabledForeignKeys.map(foreignKeyRelationshipKey),
+    );
+    const disabledForeignKeys = declaredForeignKeys.filter(
+      (foreignKey) => !enabledKeys.has(foreignKeyRelationshipKey(foreignKey)),
+    );
+
+    for (const foreignKey of disabledForeignKeys) {
+      const live = liveForeignKeys.find(
+        (candidate) =>
+          foreignKeyRelationshipKey(candidate) ===
+          foreignKeyRelationshipKey(foreignKey),
+      );
+      if (!live) continue;
+
+      const constraintName = foreignKeyConstraintName(tableName, foreignKey);
+      if (this.engine === 'postgres') {
+        changes.push({
+          type: 'drop_foreign_key',
+          table: tableName,
+          name: constraintName,
+          foreignKey,
+          sql: `ALTER TABLE ${this.quoteIdentifier(tableName)} DROP CONSTRAINT IF EXISTS ${this.quoteIdentifier(constraintName)}`,
+        });
+      } else {
+        changes.push({
+          type: 'drop_foreign_key',
+          table: tableName,
+          name: constraintName,
+          foreignKey,
+          advisory: {
+            severity: 'warning',
+            message:
+              `${this.engine === 'sqlite' ? 'SQLite' : 'DuckDB'} requires a table rebuild to remove the now-disabled physical foreign key ` +
+              `${tableName}.${foreignKey.column}. Rebuild the table from the current manifest; relationship metadata and application-side enforcement remain active.`,
+          },
+        });
+      }
+    }
+
+    for (const foreignKey of enabledForeignKeys) {
       const expectedDelete =
         foreignKey.onDelete === undefined
           ? 'NO ACTION'

--- a/packages/core/src/migrations/differ.ts
+++ b/packages/core/src/migrations/differ.ts
@@ -603,7 +603,12 @@ export class SchemaComparer {
           table: tableName,
           name: constraintName,
           foreignKey,
-          sql: `ALTER TABLE ${this.quoteIdentifier(tableName)} DROP CONSTRAINT IF EXISTS ${this.quoteIdentifier(constraintName)}`,
+          advisory: {
+            severity: 'warning',
+            message:
+              `Cannot safely remove the now-disabled physical foreign key ${tableName}.${foreignKey.column}: ` +
+              '@happyvertical/sql schema introspection does not expose the live PostgreSQL constraint name. Drop the live constraint deliberately, then rerun the migration.',
+          },
         });
       } else {
         changes.push({

--- a/packages/core/src/migrations/differ.ts
+++ b/packages/core/src/migrations/differ.ts
@@ -13,7 +13,7 @@ import {
   renderForeignKeyConstraint,
   renderForeignKeyOrphanDetector,
   renderForeignKeyOrphanRepair,
-  schemaForeignKeys,
+  schemaForeignKeysForEngine,
 } from '../schema/foreign-key-ddl.js';
 import {
   normalizeForeignKeyAction,
@@ -574,7 +574,10 @@ export class SchemaComparer {
   ): Promise<SchemaChange[]> {
     const changes: SchemaChange[] = [];
     const liveForeignKeys = dbSchema.foreignKeys || [];
-    for (const foreignKey of schemaForeignKeys(manifest)) {
+    for (const foreignKey of schemaForeignKeysForEngine(
+      manifest,
+      this.engine,
+    )) {
       const expectedDelete =
         foreignKey.onDelete === undefined
           ? 'NO ACTION'

--- a/packages/core/src/migrations/generator.ts
+++ b/packages/core/src/migrations/generator.ts
@@ -451,6 +451,19 @@ ${downStatementsStr}
         // databases may not match the deterministic current generator name.
         break;
 
+      case 'drop_foreign_key':
+        if (sqlStatements.length > 0) {
+          up.push(...sqlStatements);
+        } else if (change.advisory) {
+          up.push(
+            `-- ${change.advisory.severity === 'warning' ? 'WARNING' : 'NOTE'}: Foreign-key constraint ${change.table}.${change.name ?? 'unknown'}`,
+          );
+          up.push(`-- ${change.advisory.message}`);
+        }
+        // Re-adding a removed constraint requires a fresh orphan check and is
+        // therefore intentionally not generated as an automatic rollback.
+        break;
+
       case 'drop_index':
         if (change.name) {
           up.push(this.generateDropIndex(change.name));

--- a/packages/core/src/registry/schema-builder.ts
+++ b/packages/core/src/registry/schema-builder.ts
@@ -462,6 +462,9 @@ function applyContributorForeignKeys(
       column: toSnakeCase(targetColumn),
       onDelete: action,
       onUpdate: 'CASCADE',
+      ...(typeof field._meta?.constraint === 'object'
+        ? { engines: [...field._meta.constraint.engines] }
+        : {}),
     };
   }
 }
@@ -1083,6 +1086,9 @@ export function fieldsToColumns(
                 fieldMeta.onUpdate,
                 `${fieldName} ON UPDATE`,
               ),
+        ...(typeof fieldDef._meta?.constraint === 'object'
+          ? { engines: [...fieldDef._meta.constraint.engines] }
+          : {}),
       };
     }
 

--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -926,6 +926,9 @@ export class ManifestGenerator {
                   column: targetColumn,
                   onDelete: action,
                   onUpdate: 'CASCADE' as const,
+                  ...(typeof field._meta?.constraint === 'object'
+                    ? { engines: [...field._meta.constraint.engines] }
+                    : {}),
                 }
               : undefined,
           };
@@ -1026,6 +1029,9 @@ export class ManifestGenerator {
                 referencesColumn: definition.foreignKey.column,
                 onDelete: definition.foreignKey.onDelete,
                 onUpdate: definition.foreignKey.onUpdate,
+                ...(definition.foreignKey.engines
+                  ? { engines: definition.foreignKey.engines }
+                  : {}),
               },
             ]
           : [],

--- a/packages/core/src/scanner/types.ts
+++ b/packages/core/src/scanner/types.ts
@@ -70,8 +70,10 @@ export interface FieldMeta {
   indexed?: boolean;
   /** Foreign-key delete action carried in metadata. */
   onDelete?: 'CASCADE' | 'SET NULL' | 'RESTRICT' | 'NO ACTION';
-  /** Explicitly disables physical DDL while retaining FK relationship metadata. */
-  constraint?: boolean;
+  /** Configures physical DDL while retaining FK relationship metadata. */
+  constraint?:
+    | boolean
+    | { engines: Array<'postgres' | 'sqlite' | 'duckdb' | 'json'> };
   /** Excludes the field from persistence when true. */
   transient?: boolean;
   /** Numeric/length validation bounds and pattern. */

--- a/packages/core/src/schema/ddl/base-strategy.ts
+++ b/packages/core/src/schema/ddl/base-strategy.ts
@@ -8,7 +8,7 @@
 import { createLogger } from '@happyvertical/logger';
 import {
   renderForeignKeyConstraint,
-  schemaForeignKeys,
+  schemaForeignKeysForEngine,
 } from '../foreign-key-ddl.js';
 import {
   formatDefaultValue as formatDefaultValueShared,
@@ -81,7 +81,7 @@ export abstract class BaseDDLStrategy implements DDLStrategy {
       columnDefs.push(...uniqueConstraints);
     }
 
-    for (const foreignKey of schemaForeignKeys(schema)) {
+    for (const foreignKey of schemaForeignKeysForEngine(schema, this.engine)) {
       columnDefs.push(renderForeignKeyConstraint(tableName, foreignKey));
     }
 

--- a/packages/core/src/schema/ddl/duckdb-strategy.ts
+++ b/packages/core/src/schema/ddl/duckdb-strategy.ts
@@ -11,7 +11,7 @@
  * not with separate UNIQUE indexes. This is a known DuckDB limitation.
  */
 
-import { schemaForeignKeys } from '../foreign-key-ddl.js';
+import { schemaForeignKeysForEngine } from '../foreign-key-ddl.js';
 import { isStiSubtypeUniqueIndex, renderIndexTarget } from '../index-utils.js';
 import type { SchemaDefinition, SQLDataType } from '../types.js';
 import { BaseDDLStrategy } from './base-strategy.js';
@@ -21,31 +21,44 @@ export class DuckDBStrategy extends BaseDDLStrategy {
   readonly engine: DatabaseEngine = 'duckdb';
 
   override generateCreateTable(schema: SchemaDefinition): string {
-    const foreignKeys = schemaForeignKeys(schema).map((foreignKey) => {
-      if (foreignKey.referencesTable === schema.tableName) {
-        throw new Error(
-          `[DDL:duckdb] Foreign key ${schema.tableName}.${foreignKey.column} is self-referential; DuckDB cannot insert self-referencing foreign keys safely.`,
-        );
-      }
-      if (
-        foreignKey.onDelete === 'CASCADE' ||
-        foreignKey.onDelete === 'SET NULL'
-      ) {
-        throw new Error(
-          `[DDL:duckdb] Foreign key ${schema.tableName}.${foreignKey.column} uses ON DELETE ${foreignKey.onDelete}, which DuckDB does not support. Use PostgreSQL/SQLite or keep this relationship app-side only with @crossPackageRef.`,
-        );
-      }
-      if (foreignKey.onUpdate !== undefined) {
-        throw new Error(
-          `[DDL:duckdb] Foreign key ${schema.tableName}.${foreignKey.column} uses ON UPDATE ${foreignKey.onUpdate}, which DuckDB does not support. DuckDB cannot preserve SMRT's ON UPDATE CASCADE contract; use PostgreSQL/SQLite or keep this relationship app-side only with @crossPackageRef.`,
-        );
-      }
-      // DuckDB supports the immediate restrictive behavior but rejects the
-      // SQL action clause. Omitting it is SQL's default NO ACTION; RESTRICT is
-      // equivalent because DuckDB has no deferred constraints.
-      return { ...foreignKey, onDelete: undefined };
-    });
-    return super.generateCreateTable({ ...schema, foreignKeys });
+    const foreignKeys = schemaForeignKeysForEngine(schema, this.engine).map(
+      (foreignKey) => {
+        if (foreignKey.referencesTable === schema.tableName) {
+          throw new Error(
+            `[DDL:duckdb] Foreign key ${schema.tableName}.${foreignKey.column} is self-referential; DuckDB cannot insert self-referencing foreign keys safely.`,
+          );
+        }
+        if (
+          foreignKey.onDelete === 'CASCADE' ||
+          foreignKey.onDelete === 'SET NULL'
+        ) {
+          throw new Error(
+            `[DDL:duckdb] Foreign key ${schema.tableName}.${foreignKey.column} uses ON DELETE ${foreignKey.onDelete}, which DuckDB does not support. Use PostgreSQL/SQLite or keep this relationship app-side only with @crossPackageRef.`,
+          );
+        }
+        if (foreignKey.onUpdate !== undefined) {
+          throw new Error(
+            `[DDL:duckdb] Foreign key ${schema.tableName}.${foreignKey.column} uses ON UPDATE ${foreignKey.onUpdate}, which DuckDB does not support. DuckDB cannot preserve SMRT's ON UPDATE CASCADE contract; use PostgreSQL/SQLite or keep this relationship app-side only with @crossPackageRef.`,
+          );
+        }
+        // DuckDB supports the immediate restrictive behavior but rejects the
+        // SQL action clause. Omitting it is SQL's default NO ACTION; RESTRICT is
+        // equivalent because DuckDB has no deferred constraints.
+        return { ...foreignKey, onDelete: undefined };
+      },
+    );
+    const enabledColumns = new Set(
+      foreignKeys.map((foreignKey) => foreignKey.column),
+    );
+    const columns = Object.fromEntries(
+      Object.entries(schema.columns).map(([name, definition]) => [
+        name,
+        definition.foreignKey && !enabledColumns.has(name)
+          ? { ...definition, foreignKey: undefined }
+          : definition,
+      ]),
+    );
+    return super.generateCreateTable({ ...schema, columns, foreignKeys });
   }
 
   /**

--- a/packages/core/src/schema/foreign-key-ddl.ts
+++ b/packages/core/src/schema/foreign-key-ddl.ts
@@ -1,3 +1,4 @@
+import type { DatabaseEngine } from './ddl/types.js';
 import { requireForeignKeyAction } from './foreign-key-policy.js';
 import { shortenIdentifier } from './index-utils.js';
 import { quoteIdentifier } from './sql-identifiers.js';
@@ -83,7 +84,68 @@ export function schemaForeignKeys(
         referencesColumn: definition.foreignKey.column,
         onDelete: definition.foreignKey.onDelete,
         onUpdate: definition.foreignKey.onUpdate,
+        ...(definition.foreignKey.engines
+          ? { engines: definition.foreignKey.engines }
+          : {}),
       },
     ];
   });
+}
+
+/** Return only physical constraints explicitly enabled for an engine. */
+export function schemaForeignKeysForEngine(
+  schema: Pick<SchemaDefinition, 'columns'> &
+    Partial<Pick<SchemaDefinition, 'foreignKeys'>>,
+  engine: DatabaseEngine,
+): ForeignKeyDefinition[] {
+  return schemaForeignKeys(schema).filter((foreignKey) => {
+    if (foreignKey.engines === undefined) return true;
+
+    const validEngines = new Set<DatabaseEngine>([
+      'postgres',
+      'sqlite',
+      'duckdb',
+      'json',
+    ]);
+    if (
+      foreignKey.engines.length === 0 ||
+      foreignKey.engines.some(
+        (declaredEngine) => !validEngines.has(declaredEngine),
+      )
+    ) {
+      throw new Error(
+        `[DDL:${engine}] Foreign key ${foreignKey.column} declares an invalid physical constraint engine allowlist. Use one or more of: postgres, sqlite, duckdb, json.`,
+      );
+    }
+
+    return foreignKey.engines.includes(engine);
+  });
+}
+
+/** Return declared schema dependencies after excluding engine-disabled FKs. */
+export function schemaDependenciesForEngine(
+  schema: Pick<SchemaDefinition, 'columns'> &
+    Partial<Pick<SchemaDefinition, 'dependencies' | 'foreignKeys'>>,
+  engine: DatabaseEngine,
+): string[] {
+  const foreignKeys = schemaForeignKeys(schema);
+  const enabledForeignKeys = schemaForeignKeysForEngine(schema, engine);
+  const enabledTargets = new Set(
+    enabledForeignKeys.map((foreignKey) => foreignKey.referencesTable),
+  );
+  const disabledTargets = new Set(
+    foreignKeys
+      .filter((foreignKey) => !enabledForeignKeys.includes(foreignKey))
+      .map((foreignKey) => foreignKey.referencesTable),
+  );
+
+  return Array.from(
+    new Set([
+      ...(schema.dependencies ?? []).filter(
+        (dependency) =>
+          !disabledTargets.has(dependency) || enabledTargets.has(dependency),
+      ),
+      ...enabledTargets,
+    ]),
+  );
 }

--- a/packages/core/src/schema/foreign-key-ddl.ts
+++ b/packages/core/src/schema/foreign-key-ddl.ts
@@ -92,6 +92,20 @@ export function schemaForeignKeys(
   });
 }
 
+/** Stable identity for one physical relationship, independent of allocation. */
+export function foreignKeyRelationshipKey(
+  foreignKey: Pick<
+    ForeignKeyDefinition,
+    'column' | 'referencesColumn' | 'referencesTable'
+  >,
+): string {
+  return JSON.stringify([
+    foreignKey.column,
+    foreignKey.referencesTable,
+    foreignKey.referencesColumn,
+  ]);
+}
+
 /** Return only physical constraints explicitly enabled for an engine. */
 export function schemaForeignKeysForEngine(
   schema: Pick<SchemaDefinition, 'columns'> &
@@ -130,12 +144,17 @@ export function schemaDependenciesForEngine(
 ): string[] {
   const foreignKeys = schemaForeignKeys(schema);
   const enabledForeignKeys = schemaForeignKeysForEngine(schema, engine);
+  const enabledKeys = new Set(
+    enabledForeignKeys.map(foreignKeyRelationshipKey),
+  );
   const enabledTargets = new Set(
     enabledForeignKeys.map((foreignKey) => foreignKey.referencesTable),
   );
   const disabledTargets = new Set(
     foreignKeys
-      .filter((foreignKey) => !enabledForeignKeys.includes(foreignKey))
+      .filter(
+        (foreignKey) => !enabledKeys.has(foreignKeyRelationshipKey(foreignKey)),
+      )
       .map((foreignKey) => foreignKey.referencesTable),
   );
 

--- a/packages/core/src/schema/foreign-key-planner.ts
+++ b/packages/core/src/schema/foreign-key-planner.ts
@@ -2,7 +2,9 @@ import type { DatabaseEngine } from './ddl/types.js';
 import {
   foreignKeyConstraintName,
   renderForeignKeyConstraint,
+  schemaDependenciesForEngine,
   schemaForeignKeys,
+  schemaForeignKeysForEngine,
 } from './foreign-key-ddl.js';
 import { quoteIdentifier } from './sql-identifiers.js';
 import type { ForeignKeyDefinition, SchemaDefinition } from './types.js';
@@ -112,7 +114,7 @@ export function planForeignKeyCreation(
   const names = [...byName.keys()];
   const dependencies = new Map<string, string[]>();
   for (const [name, schema] of byName) {
-    for (const foreignKey of schemaForeignKeys(schema)) {
+    for (const foreignKey of schemaForeignKeysForEngine(schema, engine)) {
       // Validate externally supplied manifest actions before a dry-run can
       // report an executable plan.
       renderForeignKeyConstraint(name, foreignKey);
@@ -121,12 +123,9 @@ export function planForeignKeyCreation(
       name,
       Array.from(
         new Set(
-          [
-            ...(schema.dependencies ?? []),
-            ...schemaForeignKeys(schema).map(
-              (foreignKey) => foreignKey.referencesTable,
-            ),
-          ].filter((target) => target !== name && byName.has(target)),
+          schemaDependenciesForEngine(schema, engine).filter(
+            (target) => target !== name && byName.has(target),
+          ),
         ),
       ).sort(),
     );
@@ -149,7 +148,7 @@ export function planForeignKeyCreation(
 
   if (engine === 'duckdb' || engine === 'json') {
     for (const [source, schema] of byName) {
-      for (const foreignKey of schemaForeignKeys(schema)) {
+      for (const foreignKey of schemaForeignKeysForEngine(schema, engine)) {
         if (source === foreignKey.referencesTable) {
           throw new Error(
             `[DDL:${engine}] Foreign key ${source}.${foreignKey.column} is self-referential; DuckDB cannot insert self-referencing foreign keys safely.`,
@@ -196,7 +195,7 @@ export function planForeignKeyCreation(
     const schema = byName.get(name) as SchemaDefinition;
     if (engine !== 'postgres') return schema;
     const omitted = new Set<string>();
-    for (const foreignKey of schemaForeignKeys(schema)) {
+    for (const foreignKey of schemaForeignKeysForEngine(schema, engine)) {
       if (isMutualCycle(name, foreignKey.referencesTable)) {
         omitted.add(foreignKey.column);
         deferred.push({ table: name, foreignKey });

--- a/packages/core/src/schema/generator.ts
+++ b/packages/core/src/schema/generator.ts
@@ -65,6 +65,13 @@ interface RegistryField {
   _meta?: FieldMeta;
 }
 
+function getForeignKeyConstraintEngines(
+  field: RegistryField,
+): Array<'postgres' | 'sqlite' | 'duckdb' | 'json'> | undefined {
+  const constraint = field._meta?.constraint;
+  return typeof constraint === 'object' ? [...constraint.engines] : undefined;
+}
+
 type SchemaGeneratorConfig = {
   /**
    * The table's resolved conflict target. Registry callers pass
@@ -289,6 +296,9 @@ export class SchemaGenerator {
         column: this.toSnakeCase(targetColumn),
         onDelete: action,
         onUpdate: 'CASCADE',
+        ...(getForeignKeyConstraintEngines(field)
+          ? { engines: getForeignKeyConstraintEngines(field) }
+          : {}),
       };
     }
   }
@@ -988,6 +998,9 @@ export class SchemaGenerator {
           referencesColumn: columnDef.foreignKey.column,
           onDelete: columnDef.foreignKey.onDelete,
           onUpdate: columnDef.foreignKey.onUpdate,
+          ...(columnDef.foreignKey.engines
+            ? { engines: columnDef.foreignKey.engines }
+            : {}),
         });
       }
     }
@@ -1159,6 +1172,9 @@ export class SchemaGenerator {
             column: 'id',
             onDelete: onDeleteAction || 'CASCADE',
             onUpdate: 'CASCADE',
+            ...(getForeignKeyConstraintEngines(field)
+              ? { engines: getForeignKeyConstraintEngines(field) }
+              : {}),
           };
         }
       }
@@ -1501,6 +1517,9 @@ export class SchemaGenerator {
               column: 'id',
               onDelete: onDeleteAction || 'CASCADE',
               onUpdate: 'CASCADE',
+              ...(getForeignKeyConstraintEngines(field)
+                ? { engines: getForeignKeyConstraintEngines(field) }
+                : {}),
             };
           }
         }

--- a/packages/core/src/schema/issue-2413-foreign-keys.test.ts
+++ b/packages/core/src/schema/issue-2413-foreign-keys.test.ts
@@ -1,12 +1,14 @@
 import { getDatabase } from '@happyvertical/sql';
 import { describe, expect, it } from 'vitest';
-import { SchemaComparer } from '../migrations/differ.js';
+import { getSQLFromDiff, SchemaComparer } from '../migrations/differ.js';
 import { MigrationGenerator } from '../migrations/generator.js';
 import { resolveTestDatabaseDDLEngine } from '../testing/database.js';
 import { generateDDLForEngine } from './ddl/index.js';
 import {
   foreignKeyConstraintName,
+  foreignKeyRelationshipKey,
   renderForeignKeyConstraint,
+  schemaDependenciesForEngine,
   schemaForeignKeys,
 } from './foreign-key-ddl.js';
 import { planForeignKeyCreation } from './foreign-key-planner.js';
@@ -427,6 +429,31 @@ describe('deterministic creation planning (#2413)', () => {
     ).toEqual(['a_children', 'z_parents']);
   });
 
+  it('matches derived foreign keys by stable relationship semantics instead of object identity (#2504)', () => {
+    const derived = schema('derived_children', {
+      column: 'parent_id',
+      table: 'derived_parents',
+    });
+    derived.foreignKeys = [];
+    const derivedForeignKey = derived.columns.parent_id.foreignKey;
+    if (!derivedForeignKey) throw new Error('fixture foreign key missing');
+    derived.columns.parent_id.foreignKey = {
+      ...derivedForeignKey,
+      engines: ['postgres', 'sqlite'],
+    };
+
+    const first = schemaForeignKeys(derived)[0];
+    const second = schemaForeignKeys(derived)[0];
+    expect(first).not.toBe(second);
+    expect(foreignKeyRelationshipKey(first)).toBe(
+      foreignKeyRelationshipKey(second),
+    );
+    expect(schemaDependenciesForEngine(derived, 'postgres')).toEqual([
+      'derived_parents',
+    ]);
+    expect(schemaDependenciesForEngine(derived, 'duckdb')).toEqual([]);
+  });
+
   it('fails closed for empty or unknown physical-constraint engine allowlists', () => {
     const invalid = schema('children', {
       column: 'parent_id',
@@ -601,7 +628,7 @@ describe('existing-table orphan safety (#2413)', () => {
     };
   }
 
-  it('does not add an engine-disabled constraint to an existing DuckDB table (#2504)', async () => {
+  it('reports a required rebuild for a live constraint disabled on DuckDB (#2504)', async () => {
     const portableChild = structuredClone(child);
     portableChild.foreignKeys[0].engines = ['postgres', 'sqlite'];
     if (!portableChild.columns.parent_id.foreignKey) {
@@ -609,6 +636,22 @@ describe('existing-table orphan safety (#2413)', () => {
     }
     portableChild.columns.parent_id.foreignKey.engines = ['postgres', 'sqlite'];
     const mock = postgresMock(false);
+    mock.db.getTableSchema = async () => ({
+      columns: {
+        id: { name: 'id', type: 'text', primaryKey: true },
+        parent_id: { name: 'parent_id', type: 'text' },
+      },
+      indexes: [],
+      foreignKeys: [
+        {
+          column: 'parent_id',
+          referencesTable: 'parents',
+          referencesColumn: 'id',
+          onDelete: 'NO ACTION',
+          onUpdate: 'CASCADE',
+        },
+      ],
+    });
     const query = mock.db.query;
     mock.db.query = async (sql: string) => {
       if (sql.includes('sqlite_master')) {
@@ -622,10 +665,72 @@ describe('existing-table orphan safety (#2413)', () => {
       engineHint: 'duckdb',
     }).compare({ children: portableChild });
 
-    expect(
-      diff.changes.some((change) => change.type === 'add_foreign_key'),
-    ).toBe(false);
+    expect(diff.has_changes).toBe(true);
+    expect(diff.changes).toContainEqual(
+      expect.objectContaining({
+        type: 'drop_foreign_key',
+        table: 'children',
+        advisory: expect.objectContaining({
+          message: expect.stringMatching(/table rebuild/),
+        }),
+      }),
+    );
+    const migration = new MigrationGenerator({ engine: 'duckdb' })
+      .generateFromDiff(diff, { name: 'drop_disabled_duckdb_fk' })
+      .up.join('\n');
+    expect(migration).toContain(
+      '-- WARNING: Foreign-key constraint children.children_parent_id_parents_id_fkey',
+    );
+    expect(migration).toContain('requires a table rebuild');
     expect(mock.queries.some((sql) => sql.includes('orphan_key'))).toBe(false);
+  });
+
+  it('drops a live constraint disabled on PostgreSQL (#2504)', async () => {
+    const sqliteOnlyChild = structuredClone(child);
+    sqliteOnlyChild.foreignKeys[0].engines = ['sqlite'];
+    if (!sqliteOnlyChild.columns.parent_id.foreignKey) {
+      throw new Error('fixture foreign key missing');
+    }
+    sqliteOnlyChild.columns.parent_id.foreignKey.engines = ['sqlite'];
+    const mock = postgresMock(false);
+    mock.db.getTableSchema = async () => ({
+      columns: {
+        id: { name: 'id', type: 'text', primaryKey: true },
+        parent_id: { name: 'parent_id', type: 'text' },
+      },
+      indexes: [],
+      foreignKeys: [
+        {
+          column: 'parent_id',
+          referencesTable: 'parents',
+          referencesColumn: 'id',
+          onDelete: 'NO ACTION',
+          onUpdate: 'CASCADE',
+        },
+      ],
+    });
+
+    const diff = await new SchemaComparer(mock.db as never, {
+      engineHint: 'postgres',
+    }).compare({ children: sqliteOnlyChild });
+
+    expect(diff.changes).toContainEqual(
+      expect.objectContaining({
+        type: 'drop_foreign_key',
+        table: 'children',
+        sql: 'ALTER TABLE "children" DROP CONSTRAINT IF EXISTS "children_parent_id_parents_id_fkey"',
+      }),
+    );
+    expect(getSQLFromDiff(diff)).toContain(
+      'ALTER TABLE "children" DROP CONSTRAINT IF EXISTS "children_parent_id_parents_id_fkey"',
+    );
+    expect(
+      new MigrationGenerator({ engine: 'postgres' }).generateFromDiff(diff, {
+        name: 'drop_disabled_postgres_fk',
+      }).up,
+    ).toContain(
+      'ALTER TABLE "children" DROP CONSTRAINT IF EXISTS "children_parent_id_parents_id_fkey"',
+    );
   });
 
   it('probes the exact child/parent target before adding and validating on PostgreSQL', async () => {

--- a/packages/core/src/schema/issue-2413-foreign-keys.test.ts
+++ b/packages/core/src/schema/issue-2413-foreign-keys.test.ts
@@ -685,7 +685,7 @@ describe('existing-table orphan safety (#2413)', () => {
     expect(mock.queries.some((sql) => sql.includes('orphan_key'))).toBe(false);
   });
 
-  it('drops a live constraint disabled on PostgreSQL (#2504)', async () => {
+  it('does not claim a noncanonical live PostgreSQL constraint was removed (#2504)', async () => {
     const sqliteOnlyChild = structuredClone(child);
     sqliteOnlyChild.foreignKeys[0].engines = ['sqlite'];
     if (!sqliteOnlyChild.columns.parent_id.foreignKey) {
@@ -693,6 +693,11 @@ describe('existing-table orphan safety (#2413)', () => {
     }
     sqliteOnlyChild.columns.parent_id.foreignKey.engines = ['sqlite'];
     const mock = postgresMock(false);
+    // The live database uses a legacy name such as
+    // `legacy_children_parent_fk`, but @happyvertical/sql currently returns
+    // only this relationship tuple. The differ must not substitute SMRT's
+    // canonical generated name and claim that the legacy constraint was
+    // removed.
     mock.db.getTableSchema = async () => ({
       columns: {
         id: { name: 'id', type: 'text', primaryKey: true },
@@ -709,7 +714,6 @@ describe('existing-table orphan safety (#2413)', () => {
         },
       ],
     });
-
     const diff = await new SchemaComparer(mock.db as never, {
       engineHint: 'postgres',
     }).compare({ children: sqliteOnlyChild });
@@ -718,18 +722,25 @@ describe('existing-table orphan safety (#2413)', () => {
       expect.objectContaining({
         type: 'drop_foreign_key',
         table: 'children',
-        sql: 'ALTER TABLE "children" DROP CONSTRAINT IF EXISTS "children_parent_id_parents_id_fkey"',
+        advisory: expect.objectContaining({
+          message: expect.stringMatching(
+            /does not expose the live PostgreSQL constraint name/,
+          ),
+        }),
       }),
     );
-    expect(getSQLFromDiff(diff)).toContain(
-      'ALTER TABLE "children" DROP CONSTRAINT IF EXISTS "children_parent_id_parents_id_fkey"',
+    const change = diff.changes.find(
+      (candidate) => candidate.type === 'drop_foreign_key',
     );
-    expect(
-      new MigrationGenerator({ engine: 'postgres' }).generateFromDiff(diff, {
-        name: 'drop_disabled_postgres_fk',
-      }).up,
-    ).toContain(
-      'ALTER TABLE "children" DROP CONSTRAINT IF EXISTS "children_parent_id_parents_id_fkey"',
+    expect(change?.sql).toBeUndefined();
+    expect(getSQLFromDiff(diff)).not.toContain('DROP CONSTRAINT');
+    const migration = new MigrationGenerator({ engine: 'postgres' })
+      .generateFromDiff(diff, { name: 'manual_disabled_postgres_fk' })
+      .up.join('\n');
+    expect(migration).toContain('-- WARNING: Foreign-key constraint');
+    expect(migration).not.toContain('DROP CONSTRAINT');
+    expect(mock.queries.some((sql) => sql.includes('constraint_name'))).toBe(
+      false,
     );
   });
 

--- a/packages/core/src/schema/issue-2413-foreign-keys.test.ts
+++ b/packages/core/src/schema/issue-2413-foreign-keys.test.ts
@@ -350,6 +350,99 @@ describe('deterministic creation planning (#2413)', () => {
       ),
     ).toThrow(/self-referential/);
   });
+
+  it('honors an explicit physical-constraint engine allowlist without weakening other self-references (#2504)', () => {
+    const portableHierarchy = schema('event_nodes', {
+      column: 'parent_id',
+      table: 'event_nodes',
+    });
+    const parentForeignKey = portableHierarchy.columns.parent_id.foreignKey;
+    if (!parentForeignKey)
+      throw new Error('fixture parent foreign key missing');
+    portableHierarchy.columns.parent_id.foreignKey = {
+      ...parentForeignKey,
+      engines: ['postgres', 'sqlite'],
+    };
+    portableHierarchy.foreignKeys = schemaForeignKeys({
+      columns: portableHierarchy.columns,
+      foreignKeys: [],
+    });
+
+    for (const engine of ['postgres', 'sqlite'] as const) {
+      expect(
+        generateDDLForEngine(portableHierarchy, engine).createTable,
+      ).toContain('FOREIGN KEY ("parent_id")');
+      expect(
+        planForeignKeyCreation([portableHierarchy], engine).schemas[0]
+          .foreignKeys,
+      ).toHaveLength(1);
+    }
+    for (const engine of ['duckdb', 'json'] as const) {
+      expect(
+        generateDDLForEngine(portableHierarchy, engine).createTable,
+      ).not.toContain('FOREIGN KEY ("parent_id")');
+      expect(
+        planForeignKeyCreation([portableHierarchy], engine).schemas[0]
+          .foreignKeys,
+      ).toHaveLength(1);
+    }
+
+    expect(() =>
+      generateDDLForEngine(
+        schema('arbitrary_nodes', {
+          column: 'parent_id',
+          table: 'arbitrary_nodes',
+        }),
+        'duckdb',
+      ),
+    ).toThrow(/self-referential/);
+  });
+
+  it('excludes engine-disabled relationships from dependency planning (#2504)', () => {
+    const child = schema('a_children', {
+      column: 'parent_id',
+      table: 'z_parents',
+    });
+    const childForeignKey = child.columns.parent_id.foreignKey;
+    if (!childForeignKey) throw new Error('fixture foreign key missing');
+    child.columns.parent_id.foreignKey = {
+      ...childForeignKey,
+      engines: ['postgres', 'sqlite'],
+    };
+    child.foreignKeys = schemaForeignKeys({
+      columns: child.columns,
+      foreignKeys: [],
+    });
+    const parent = schema('z_parents');
+
+    expect(
+      planForeignKeyCreation([child, parent], 'postgres').schemas.map(
+        (item) => item.tableName,
+      ),
+    ).toEqual(['z_parents', 'a_children']);
+    expect(
+      planForeignKeyCreation([child, parent], 'duckdb').schemas.map(
+        (item) => item.tableName,
+      ),
+    ).toEqual(['a_children', 'z_parents']);
+  });
+
+  it('fails closed for empty or unknown physical-constraint engine allowlists', () => {
+    const invalid = schema('children', {
+      column: 'parent_id',
+      table: 'parents',
+    });
+
+    invalid.foreignKeys[0].engines = [];
+    expect(() => generateDDLForEngine(invalid, 'duckdb')).toThrow(
+      /invalid physical constraint engine allowlist/,
+    );
+
+    invalid.foreignKeys[0].engines = ['mysql'] as never;
+    expect(() => planForeignKeyCreation([invalid], 'postgres')).toThrow(
+      /invalid physical constraint engine allowlist/,
+    );
+  });
 });
 
 describe('SQLite database enforcement (#2413)', () => {
@@ -507,6 +600,33 @@ describe('existing-table orphan safety (#2413)', () => {
       },
     };
   }
+
+  it('does not add an engine-disabled constraint to an existing DuckDB table (#2504)', async () => {
+    const portableChild = structuredClone(child);
+    portableChild.foreignKeys[0].engines = ['postgres', 'sqlite'];
+    if (!portableChild.columns.parent_id.foreignKey) {
+      throw new Error('fixture foreign key missing');
+    }
+    portableChild.columns.parent_id.foreignKey.engines = ['postgres', 'sqlite'];
+    const mock = postgresMock(false);
+    const query = mock.db.query;
+    mock.db.query = async (sql: string) => {
+      if (sql.includes('sqlite_master')) {
+        mock.queries.push(sql);
+        return { rows: [{ name: 'children' }] } as never;
+      }
+      return query(sql);
+    };
+
+    const diff = await new SchemaComparer(mock.db as never, {
+      engineHint: 'duckdb',
+    }).compare({ children: portableChild });
+
+    expect(
+      diff.changes.some((change) => change.type === 'add_foreign_key'),
+    ).toBe(false);
+    expect(mock.queries.some((sql) => sql.includes('orphan_key'))).toBe(false);
+  });
 
   it('probes the exact child/parent target before adding and validating on PostgreSQL', async () => {
     const mock = postgresMock(false);

--- a/packages/core/src/schema/manifest-schema.ts
+++ b/packages/core/src/schema/manifest-schema.ts
@@ -147,6 +147,9 @@ export function manifestSchemaToDefinition(
             referencesColumn: definition.foreignKey.column,
             onDelete: definition.foreignKey.onDelete,
             onUpdate: definition.foreignKey.onUpdate,
+            ...(definition.foreignKey.engines
+              ? { engines: definition.foreignKey.engines }
+              : {}),
           },
         ]
       : [],

--- a/packages/core/src/schema/schema-path-parity.test.ts
+++ b/packages/core/src/schema/schema-path-parity.test.ts
@@ -123,6 +123,11 @@ function buildFixtureManifest(): SmartObjectManifest {
     objectDef('ParityPost', {
       body: { type: 'text' },
       authorId: { type: 'foreignKey', related: 'ParityAuthor' },
+      portableAuthorId: {
+        type: 'foreignKey',
+        related: 'ParityAuthor',
+        _meta: { constraint: { engines: ['postgres', 'sqlite'] } },
+      },
       archiveAuthorId: {
         type: 'foreignKey',
         related: 'ParityAuthor',
@@ -411,6 +416,7 @@ function columnSet(
         column: string;
         onDelete?: string;
         onUpdate?: string;
+        engines?: string[];
       };
     }
   >,
@@ -420,7 +426,7 @@ function columnSet(
     a.localeCompare(b),
   )) {
     const fk = col.foreignKey
-      ? `${col.foreignKey.table}.${col.foreignKey.column}/${col.foreignKey.onDelete ?? '-'}/${col.foreignKey.onUpdate ?? '-'}`
+      ? `${col.foreignKey.table}.${col.foreignKey.column}/${col.foreignKey.onDelete ?? '-'}/${col.foreignKey.onUpdate ?? '-'}/${col.foreignKey.engines?.join(',') ?? '-'}`
       : '-';
     out[name] =
       `${String(col.type).toUpperCase()}/${col.referenceKind ?? '-'}/${fk}`;
@@ -483,6 +489,9 @@ function manifestSchemaAsDefinition(
                 referencesColumn: definition.foreignKey.column,
                 onDelete: definition.foreignKey.onDelete,
                 onUpdate: definition.foreignKey.onUpdate,
+                ...(definition.foreignKey.engines
+                  ? { engines: definition.foreignKey.engines }
+                  : {}),
               },
             ]
           : [],
@@ -855,6 +864,7 @@ describe('schema path parity (#2359)', () => {
         'parity_posts_archive_author_id_idx',
         'parity_posts_author_id_idx',
         'parity_posts_created_at_idx',
+        'parity_posts_portable_author_id_idx',
         'parity_posts_profile_id_idx',
         'parity_posts_slug_context_idx',
         'parity_posts_status_idx',
@@ -875,6 +885,16 @@ describe('schema path parity (#2359)', () => {
         column: 'id',
         onDelete: 'NO ACTION',
         onUpdate: 'CASCADE',
+      });
+      expect(
+        manifestSchemas.get('parity_posts')?.columns.portable_author_id
+          .foreignKey,
+      ).toEqual({
+        table: 'parity_authors',
+        column: 'id',
+        onDelete: 'NO ACTION',
+        onUpdate: 'CASCADE',
+        engines: ['postgres', 'sqlite'],
       });
       expect(
         manifestSchemas.get('parity_posts')?.columns.profile_id.foreignKey,

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -345,6 +345,7 @@ export interface SchemaChange {
     | 'orphan_column'
     | 'add_index'
     | 'add_foreign_key'
+    | 'drop_foreign_key'
     | 'drop_index'
     | 'orphan_index'
     | 'type_mismatch'
@@ -357,7 +358,7 @@ export interface SchemaChange {
   column?: ColumnDefinition;
   /** Index definition (for add_index) */
   index?: IndexDefinition;
-  /** Foreign-key definition (for add_foreign_key). */
+  /** Foreign-key definition (for add_foreign_key/drop_foreign_key). */
   foreignKey?: ForeignKeyDefinition;
   /**
    * For type mismatches/upgrades: expected vs actual type. For

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -34,6 +34,8 @@ export interface ColumnDefinition {
     column: string;
     onDelete?: ForeignKeyAction;
     onUpdate?: ForeignKeyAction;
+    /** Engines on which the physical constraint is emitted. */
+    engines?: Array<'postgres' | 'sqlite' | 'duckdb' | 'json'>;
   };
   check?: string; // CHECK constraint
   description?: string;
@@ -118,6 +120,8 @@ export interface ForeignKeyDefinition {
   referencesColumn: string;
   onDelete?: ForeignKeyAction;
   onUpdate?: ForeignKeyAction;
+  /** Engines on which the physical constraint is emitted. */
+  engines?: Array<'postgres' | 'sqlite' | 'duckdb' | 'json'>;
 }
 
 export interface SchemaDefinition {

--- a/packages/core/src/schema/utils.ts
+++ b/packages/core/src/schema/utils.ts
@@ -13,8 +13,8 @@ import type { SmrtObject } from '../object.js';
 import { ObjectRegistry } from '../registry.js';
 import type { FieldDefinition } from '../scanner/types.js';
 import { tableNameFromClass } from '../utils.js';
-import type { DatabaseEngine } from './ddl/types.js';
-import { schemaForeignKeys } from './foreign-key-ddl.js';
+import { type DatabaseEngine, detectEngine } from './ddl/index.js';
+import { schemaDependenciesForEngine } from './foreign-key-ddl.js';
 import { SchemaManager } from './schema-manager.js';
 
 export {
@@ -303,17 +303,15 @@ export async function ensureSchema(
   // one unit; creating the requested table alone would leave the first
   // PostgreSQL CREATE referencing a table that does not exist (#2413).
   const allSchemas = ObjectRegistry.getAllSchemasAsDefinitions();
+  const engine =
+    typeof (db as { exportTable?: unknown }).exportTable === 'function'
+      ? 'json'
+      : detectEngine(db.url);
   const required = new Map<string, typeof effectiveSchemaDefinition>();
   const collect = (schema: typeof effectiveSchemaDefinition): void => {
     if (required.has(schema.tableName)) return;
     required.set(schema.tableName, schema);
-    const dependencies = new Set([
-      ...schema.dependencies,
-      ...schemaForeignKeys(schema).map(
-        (foreignKey) => foreignKey.referencesTable,
-      ),
-    ]);
-    for (const dependency of dependencies) {
+    for (const dependency of schemaDependenciesForEngine(schema, engine)) {
       const dependencySchema = allSchemas[dependency];
       if (dependencySchema) collect(dependencySchema);
     }

--- a/packages/core/src/testing/database.ts
+++ b/packages/core/src/testing/database.ts
@@ -27,7 +27,10 @@ import {
 } from '../registry/collection-resolution.js';
 import { ObjectRegistry } from '../registry.js';
 import { detectEngine } from '../schema/ddl/index.js';
-import { schemaForeignKeys } from '../schema/foreign-key-ddl.js';
+import {
+  schemaForeignKeys,
+  schemaForeignKeysForEngine,
+} from '../schema/foreign-key-ddl.js';
 import { planForeignKeyCreation } from '../schema/foreign-key-planner.js';
 import { SchemaGenerator } from '../schema/generator.js';
 import type { SchemaDefinition } from '../schema/types.js';
@@ -502,7 +505,7 @@ export async function getTestDatabase(
   // Add the authoritative dependency closure so a child-only request cannot
   // emit a physical reference to a table this helper never creates.
   const addDependencies = (schema: SchemaDefinition): void => {
-    for (const foreignKey of schemaForeignKeys(schema)) {
+    for (const foreignKey of schemaForeignKeysForEngine(schema, ddlEngine)) {
       if (schemas.has(foreignKey.referencesTable)) continue;
       const dependency = authoritativeSchemas[foreignKey.referencesTable];
       if (!dependency) continue;

--- a/packages/events/AGENTS.md
+++ b/packages/events/AGENTS.md
@@ -16,5 +16,10 @@ Infinite-nesting event hierarchy with series, types, participants, and role/plac
 - **Placement is numeric**: used for both team ordering (0=home, 1=away) and rankings — context-dependent
 - **GroupId not enforced at DB level**: for logical grouping only (e.g., team members in a game)
 - **Optional tenancy** with nullable tenantId
+- **Event physical foreign keys**: `parentId`, `seriesId`, and `typeId` retain
+  PostgreSQL/SQLite constraints. DuckDB/JSON omit only those explicitly scoped
+  physical constraints because DuckDB cannot enforce Event's self-reference or
+  generated `ON UPDATE CASCADE`; UUID fields, indexes, relationship loading,
+  and application-side delete enforcement remain active on every engine.
 - **Metadata stored as JSON string** with get/set/update helpers
 - **Owned asset helpers**: use `Event.getAssets()` / `addAsset()` / `removeAsset()` or the matching `EventCollection` wrappers instead of generic `AssetAssociation`

--- a/packages/events/src/__tests__/issue-2504-event-json-hierarchy.test.ts
+++ b/packages/events/src/__tests__/issue-2504-event-json-hierarchy.test.ts
@@ -1,0 +1,67 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SmrtCollection, smrt } from '@happyvertical/smrt-core';
+import { getTestDatabase } from '@happyvertical/smrt-core/testing';
+import { getDatabase } from '@happyvertical/sql';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Event, EventCollection } from '../index.js';
+
+@smrt()
+class Issue2504Meeting extends Event {}
+
+class Issue2504MeetingCollection extends SmrtCollection<Issue2504Meeting> {
+  static readonly _itemClass = Issue2504Meeting;
+}
+
+describe('Event hierarchy on the DuckDB-backed JSON adapter (#2504)', () => {
+  let testDir: string | undefined;
+
+  afterEach(() => {
+    if (testDir) rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('persists an STI child parentId and rehydrates it by _meta_type after reload', async () => {
+    testDir = mkdtempSync(join(tmpdir(), 'smrt-event-json-hierarchy-'));
+    const db = await getDatabase({
+      type: 'json',
+      url: testDir,
+      writeStrategy: 'immediate',
+    });
+    await getTestDatabase({
+      db,
+      classes: ['Event'],
+      includeSystemTables: false,
+    });
+    const events = await EventCollection.create({ db });
+    const meetings = await Issue2504MeetingCollection.create({ db });
+    const root = await events.create({ name: 'Council session' });
+    const child = await meetings.create({
+      name: 'Public hearing',
+      parentId: root.id,
+    });
+
+    const reloadedDb = await getDatabase({
+      type: 'json',
+      url: testDir,
+      writeStrategy: 'immediate',
+    });
+    const reloadedEvents = await EventCollection.create({ db: reloadedDb });
+    const reloaded = await reloadedEvents.list({});
+    const reloadedChild = reloaded.find((event) => event.id === child.id);
+
+    expect(reloadedChild).toBeInstanceOf(Issue2504Meeting);
+    expect(reloadedChild?.parentId).toBe(root.id);
+    expect((await reloadedChild?.getParent())?.id).toBe(root.id);
+
+    const subtypeRows = await reloadedDb.query<{
+      id: string;
+      parent_id: string;
+    }>('SELECT id, parent_id FROM events WHERE _meta_type = ?', [
+      '@happyvertical/smrt-events:Issue2504Meeting',
+    ]);
+    expect(subtypeRows.rows).toEqual([
+      expect.objectContaining({ id: child.id, parent_id: root.id }),
+    ]);
+  });
+});

--- a/packages/events/src/models/Event.ts
+++ b/packages/events/src/models/Event.ts
@@ -31,10 +31,21 @@ export class Event extends SmrtHierarchical {
   tenantId: string | null = null;
 
   name: string = '';
-  @foreignKey('EventSeries')
+  @foreignKey('EventSeries', {
+    constraint: { engines: ['postgres', 'sqlite'] },
+  })
   seriesId = ''; // FK to EventSeries (nullable for standalone events)
-  // parentId inherited from SmrtHierarchical (self-reference to parent Event)
-  @foreignKey('EventType')
+  // DuckDB cannot enforce a self-FK; PostgreSQL/SQLite retain the physical
+  // constraint while every engine retains UUID relationship semantics and
+  // application-side delete enforcement.
+  @foreignKey('Event', {
+    nullable: true,
+    constraint: { engines: ['postgres', 'sqlite'] },
+  })
+  override parentId: string | null = null;
+  @foreignKey('EventType', {
+    constraint: { engines: ['postgres', 'sqlite'] },
+  })
   typeId = ''; // FK to EventType
   @crossPackageRef('@happyvertical/smrt-places:Place')
   placeId = ''; // FK to Place (from @happyvertical/smrt-places)

--- a/packages/scanner/src/__tests__/manifest-adapter-conversion.test.ts
+++ b/packages/scanner/src/__tests__/manifest-adapter-conversion.test.ts
@@ -253,6 +253,30 @@ describe('ManifestAdapter conversion', () => {
     });
   });
 
+  describe('@foreignKey decorator physical constraints', () => {
+    it('preserves the explicit engine allowlist in field metadata (#2504)', () => {
+      const result = adapter.convertField(
+        field({
+          name: 'parentId',
+          typeAnnotation: 'string | null',
+          decorators: [
+            {
+              name: 'foreignKey',
+              arguments: [
+                "'Event'",
+                "{ nullable: true, constraint: { engines: ['postgres', 'sqlite'] } }",
+              ],
+            },
+          ],
+        }),
+      );
+
+      expect(result?._meta?.constraint).toEqual({
+        engines: ['postgres', 'sqlite'],
+      });
+    });
+  });
+
   describe('convertMethod', () => {
     it('drops private/protected methods', () => {
       expect(

--- a/packages/scanner/src/manifest-adapter.ts
+++ b/packages/scanner/src/manifest-adapter.ts
@@ -72,6 +72,10 @@ type FieldDecoratorOptions = {
   unique?: boolean;
   /** crossPackageRef opt-in save-time validation */
   validate?: boolean;
+  /** Physical foreign-key constraint engine allowlist. */
+  constraint?:
+    | boolean
+    | { engines: Array<'postgres' | 'sqlite' | 'duckdb' | 'json'> };
   /** manyToMany junction table name */
   through?: string;
   /** manyToMany override of the source-side join column */
@@ -895,6 +899,7 @@ export class ManifestAdapter {
         'unique',
         'description',
         'default',
+        'constraint',
       ] as const;
       if (parsedOptions) {
         for (const key of META_KEYS) {


### PR DESCRIPTION
## Summary

- add a public per-engine physical foreign-key constraint allowlist carried through decorators, scanner manifests, registry schemas, migration diffing, dependency planning, and DDL generation
- keep Event parent/series/type relationships physically enforced on PostgreSQL and SQLite while preserving UUID/reference/index/application semantics on DuckDB-backed JSON storage
- reconcile existing engine-disabled constraints as explicit fail-closed manual drift, without guessed PostgreSQL names or compatibility catalog queries
- surface manual foreign-key drift consistently through db:diff, db:migrate, and human/JSON db:status
- keep DuckDB fail-closed for unsupported constraints, cycles, actions, and invalid engine declarations; no arbitrary silent stripping
- add real Event STI JSON persistence/reload plus schema-path, migration, DDL, scanner, and CLI parity coverage
- document the engine-scoped contract in core and events guidance

## Validation

- @happyvertical/smrt-core: 300 files passed, 4,013 tests passed, 112 skipped
- @happyvertical/smrt-events: 140 tests passed
- @happyvertical/smrt-scanner: 238 tests passed
- @happyvertical/smrt-cli: 62 files passed, 910 tests passed, 7 skipped
- focused core/scanner FK, DDL, migration, and schema-parity suite: 124 tests passed
- focused CLI db:diff, db:migrate, and human/JSON db:status suite: 104 tests passed
- Event JSON hierarchy reload/STI regression: passed
- affected dependency build/typecheck matrix: 26 tasks passed
- Biome, strict knowledge check, pre-push policy checks, and diff check: passed
- high-risk review-cycle: balanced preliminary roster converged; smartest final full-diff roster CLEAR at exact head
- dedicated exact-head QA: PASS
- final exact-head gate review: APPROVE for push/PR update

## Environment note

No authorized local PostgreSQL service URL was available. PostgreSQL behavior is covered locally by production DDL generation, migration diff, and schema-path/planner parity tests; live PostgreSQL and Required CI remain mandatory before merge.

Closes #2504

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-issue-2504-20260825T0054Z",
  "issue": 2504,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "core full suite: 4013 passed, 112 skipped",
    "events full suite: 140 passed",
    "scanner full suite: 238 passed",
    "CLI full suite: 910 passed, 7 skipped",
    "focused core/scanner FK, DDL, migration, and parity: 124 passed",
    "focused CLI diff, migrate, and status: 104 passed",
    "Event JSON hierarchy reload/STI regression",
    "affected dependency build and typecheck: 26 tasks",
    "Biome, strict knowledge, pre-push policy, and diff checks",
    "high-risk exact-head preliminary and final review-cycle",
    "dedicated exact-head QA and final gate review"
  ]
}
```
