### PR TITLE
fix(playground): reset cleared controlled selection

### DIFF
--- a/packages/smrt-playground/README.md
+++ b/packages/smrt-playground/README.md
@@ -35,6 +35,11 @@ That module should:
 
 The shared host discovers these modules and renders them. Package pages do not need to be mounted into the shared playground.
 
+`PlaygroundHost` accepts a qualified entry ID through `selectedEntryId`. When a
+parent changes a non-null controlled selection to `null`, the host restores its
+default module and entry. This keeps reactive route state aligned in both
+directions without remounting the host.
+
 ## Relationship To `smrt playground`
 
 The `smrt playground` CLI commands are the public entry point.

--- a/packages/smrt-playground/host/e2e/shared-playground.spec.ts
+++ b/packages/smrt-playground/host/e2e/shared-playground.spec.ts
@@ -16,6 +16,59 @@ function trackPlaygroundErrors(page: Page) {
   return errors;
 }
 
+async function followClientLink(page: Page, href: string) {
+  await page.evaluate((target) => {
+    document.querySelector('[data-testid="client-navigation"]')?.remove();
+    const link = document.createElement('a');
+    link.dataset.testid = 'client-navigation';
+    link.href = target;
+    link.textContent = 'Navigate';
+    document.body.append(link);
+  }, href);
+  await page.locator('[data-testid="client-navigation"]').click();
+}
+
+test('controlled entry follows same-page query navigation in both directions', async ({
+  page,
+}) => {
+  const errors = trackPlaygroundErrors(page);
+  const controlledEntryId =
+    '@happyvertical/smrt-content:content-editor';
+
+  await page.goto('/');
+  await expect(page.locator('[data-hydrated="true"]')).toBeVisible();
+  const mountedHost = await page.locator('[data-hydrated="true"]').elementHandle();
+  expect(mountedHost).not.toBeNull();
+  await expect(page.getByTestId('playground-selected-package')).toHaveText(
+    '@happyvertical/smrt-ui',
+  );
+
+  await followClientLink(
+    page,
+    `/?entry=${encodeURIComponent(controlledEntryId)}`,
+  );
+  await expect(page).toHaveURL(
+    new RegExp(`entry=${encodeURIComponent(controlledEntryId)}`),
+  );
+  await expect(page.getByTestId('playground-preview-title')).toHaveText(
+    'Content Editor',
+  );
+  expect(await mountedHost?.evaluate((element) => element.isConnected)).toBe(
+    true,
+  );
+
+  await followClientLink(page, '/');
+  await expect(page).toHaveURL(/\/$/);
+  await expect(page.getByTestId('playground-selected-package')).toHaveText(
+    '@happyvertical/smrt-ui',
+  );
+  expect(await mountedHost?.evaluate((element) => element.isConnected)).toBe(
+    true,
+  );
+
+  expect(errors).toEqual([]);
+});
+
 test('shared host renders content reference previews and governance modes', async ({
   page,
 }) => {

--- a/packages/smrt-playground/host/src/routes/+page.svelte
+++ b/packages/smrt-playground/host/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import '@happyvertical/smrt-ui/themes/styles/fonts.css';
+import { page } from '$app/state';
 import { PlaygroundHost } from '@happyvertical/smrt-playground/svelte';
 import { playgroundModules } from 'virtual:smrt-playground/modules';
 </script>
@@ -8,4 +9,5 @@ import { playgroundModules } from 'virtual:smrt-playground/modules';
   title="SMRT Package Playground"
   subtitle="Workspace packages publish their own previews; this host simply discovers and renders them."
   modules={playgroundModules}
+  selectedEntryId={page.url.searchParams.get('entry')}
 />

--- a/packages/smrt-playground/src/svelte/PlaygroundHost.svelte
+++ b/packages/smrt-playground/src/svelte/PlaygroundHost.svelte
@@ -20,6 +20,10 @@ export interface Props {
   title?: string;
   subtitle?: string;
   embedded?: boolean;
+  /**
+   * Qualified entry ID controlled by the parent. Clearing a previously
+   * controlled selection restores the playground's default selection.
+   */
   selectedEntryId?: string | null;
   hideEntryList?: boolean;
 }
@@ -45,6 +49,7 @@ let selectedModuleName = $state<string | null>(null);
 let selectedEntryId = $state<string | null>(null);
 let selectedMode = $state<SmrtPlaygroundMode>('mock');
 let isHydrated = $state(false);
+let previousControlledSelectedEntryId: string | null = null;
 const inheritedThemeContext = tryGetThemeContext();
 
 onMount(() => {
@@ -133,6 +138,11 @@ const foundationGroups = $derived.by(() => {
 });
 
 $effect(() => {
+  const controlledSelectionWasCleared =
+    previousControlledSelectedEntryId !== null &&
+    controlledSelectedEntryId === null;
+  previousControlledSelectedEntryId = controlledSelectedEntryId;
+
   const controlledModule = controlledSelectedEntryId
     ? (orderedModules.find((module) =>
         module.entries.some(
@@ -144,6 +154,16 @@ $effect(() => {
   if (!firstModule) {
     selectedModuleName = null;
     selectedEntryId = null;
+    return;
+  }
+
+  if (controlledSelectionWasCleared) {
+    selectedModuleName = firstModule.packageName;
+    selectedEntryId =
+      firstModule.packageName === foundationPackageName || hideEntryList
+        ? (firstModule.entries[0]?.qualifiedId ?? null)
+        : null;
+    selectedMode = firstModule.entries[0]?.availableModes[0] ?? 'mock';
     return;
   }
 


### PR DESCRIPTION
## Summary

- reset PlaygroundHost to its default module and entry when a controlled qualified entry changes to null
- bind the standalone host to reactive SvelteKit query state
- cover query add/remove navigation on the same mounted host instance and document the contract

## ASD-STE100 public-prose evidence

- Scope reviewed: the changed README text and the selectedEntryId public prop documentation.
- Evidence: the prose uses short declarative sentences, active voice, one state per sentence, and consistent controlled-selection and default-selection terms.
- Terminology: “application logic” is the approved term. The change introduces no “business logic” usage; that quoted occurrence is metadata-only audit evidence.

## Validation

- pnpm --dir packages/smrt-playground check
- pnpm --dir packages/smrt-playground test
- pnpm --dir packages/smrt-playground build
- pnpm --dir packages/smrt-playground typecheck
- pnpm --dir packages/smrt-playground verify:pack
- pnpm --dir packages/smrt-playground/host build
- pnpm exec playwright test -c playwright.codex.config.ts (3 passed; temporary alternate-port config removed)
- pnpm build
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm format
- pnpm smrt dev:knowledge-check
- pnpm audit:policy
- pre-commit and pre-push repository gates
- independent review cycle: clean on 411ace19bebcca1123050ce087cc78c36b4dee95
- ASD-STE100 public-prose audit: passed; approved term is “application logic”; source diff has no “business logic” usage

Closes #2506

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-issue-2506-01a036ba",
  "issue": 2506,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "pnpm --dir packages/smrt-playground check",
    "pnpm --dir packages/smrt-playground test",
    "pnpm --dir packages/smrt-playground build",
    "pnpm --dir packages/smrt-playground typecheck",
    "pnpm --dir packages/smrt-playground verify:pack",
    "pnpm --dir packages/smrt-playground/host build",
    "pnpm exec playwright test -c playwright.codex.config.ts",
    "pnpm build",
    "pnpm test",
    "pnpm typecheck",
    "pnpm lint",
    "pnpm format",
    "pnpm smrt dev:knowledge-check",
    "pnpm audit:policy",
    "review-cycle clean on 411ace19bebcca1123050ce087cc78c36b4dee95",
    "ASD-STE100 public-prose audit passed: approved term is application logic; source diff has no business logic usage"
  ]
}
