### PR TITLE
fix(smrt-workbench): remove stale MCP session text

### DIFF
--- a/packages/smrt-app-mcp/README.md
+++ b/packages/smrt-app-mcp/README.md
@@ -72,9 +72,9 @@ reviewed catalog where every allowed tool is unauthenticated, read-only, and
 global. The server verifies that shape (including the absence of tenant-scoped
 tools and principal-aware policy) and falls back to `private` otherwise.
 
-The route constructs a fresh protocol server for every HTTP request. It does
-not issue or rely on `Mcp-Session-Id`, sticky load-balancer routing, or a held
-SSE connection, so it is safe behind ordinary round-robin deployment. This
+The route constructs a fresh protocol server for every HTTP request. It relies
+on no transport session state, sticky load-balancer routing, or held event
+stream, so it is safe behind ordinary round-robin deployment. This
 mount exposes no subscription capability; subscription requests are refused as
 a JSON-RPC error before any SSE stream opens. Persist stateful workflow
 progress in application objects, then pass their explicit s-m-r-t object id


### PR DESCRIPTION
## Summary

- remove the retired MCP session-header wording from the `smrt-app-mcp` README
- preserve the stateless per-request transport contract in source prose
- prevent the workbench documentation bundler from copying the banned token into generated JavaScript

## Validation

- `pnpm build`
- confirmed the generated workbench host contains no stale MCP session wording
- `pnpm check:mcp-protocol-hygiene`
- `pnpm --filter @happyvertical/smrt-workbench test` (19 passed)
- `pnpm --filter @happyvertical/smrt-workbench typecheck`
- `pnpm --filter @happyvertical/smrt-app-mcp test` (48 passed)
- `pnpm --filter @happyvertical/smrt-app-mcp typecheck`
- `pnpm test:mcp-conformance` (13 passed across three suites)
- `pnpm typecheck` (125 tasks passed)
- `pnpm smrt dev:knowledge-check --format markdown`
- `pnpm knowledge:check --strict --format markdown`
- `pnpm audit:policy`
- pre-push repository guard suite

The full local `pnpm test` floor was also attempted. Two unrelated tests outside the changed packages were intermittently unstable under local Node 22: one `smrt-fields` assertion passed immediately in isolation, and one `smrt-video` test exceeded its timeout. The focused suites above are green; required CI remains authoritative for the repository-wide floor.

Closes #2508

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-issue-2508-20260824",
  "issue": 2508,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "pnpm build",
    "pnpm check:mcp-protocol-hygiene",
    "pnpm --filter @happyvertical/smrt-workbench test",
    "pnpm --filter @happyvertical/smrt-workbench typecheck",
    "pnpm --filter @happyvertical/smrt-app-mcp test",
    "pnpm --filter @happyvertical/smrt-app-mcp typecheck",
    "pnpm test:mcp-conformance",
    "pnpm typecheck",
    "pnpm smrt dev:knowledge-check --format markdown",
    "pnpm knowledge:check --strict --format markdown",
    "pnpm audit:policy"
  ]
}
