### PR TITLE
fix(core): preserve concrete inherited field metadata

### DIFF
--- a/packages/core/src/scanner/__tests__/manifest-generator-coverage.test.ts
+++ b/packages/core/src/scanner/__tests__/manifest-generator-coverage.test.ts
@@ -827,5 +827,66 @@ describe('ManifestGenerator coverage', () => {
       expect(node.fields.parentId.type).toBe('foreignKey');
       expect(node.fields.parentId.related).toBe('Node');
     });
+
+    it('preserves a concrete external STI parentId refinement for a local child (#2504)', () => {
+      writeExternalPackage({
+        [`${EXT_PKG}:SmrtHierarchical`]: {
+          className: 'SmrtHierarchical',
+          collection: '',
+          fields: { parentId: { type: 'text', _meta: {} } },
+          decoratorConfig: {},
+        },
+        [`${EXT_PKG}:Event`]: {
+          className: 'Event',
+          qualifiedName: `${EXT_PKG}:Event`,
+          extends: 'SmrtHierarchical',
+          collection: 'events',
+          fields: {
+            parentId: {
+              type: 'foreignKey',
+              related: 'Event',
+              required: false,
+              _meta: {
+                nullable: true,
+                constraint: { engines: ['postgres', 'sqlite'] },
+              },
+            },
+          },
+          decoratorConfig: { tableStrategy: 'sti', tableName: 'events' },
+        },
+      });
+
+      process.chdir(dir);
+      const gen = new ManifestGenerator();
+      const manifest = gen.generateManifest(
+        [
+          scan([
+            def('Meeting', {
+              extends: 'Event',
+              fields: { agenda: { type: 'text' } },
+            }),
+          ]),
+        ],
+        { smrtDependencies: [EXT_PKG] },
+      );
+
+      const meeting = manifest.objects.meeting;
+      expect(meeting.decoratorConfig).toMatchObject({
+        tableStrategy: 'sti',
+        tableName: 'events',
+      });
+      expect(meeting.fields.parentId).toMatchObject({
+        type: 'foreignKey',
+        related: 'Event',
+        required: false,
+        _meta: {
+          nullable: true,
+          constraint: { engines: ['postgres', 'sqlite'] },
+        },
+      });
+      expect(meeting.schema?.columns.parent_id?.foreignKey).toMatchObject({
+        engines: ['postgres', 'sqlite'],
+      });
+    });
   });
 });

--- a/packages/core/src/scanner/manifest-generator.ts
+++ b/packages/core/src/scanner/manifest-generator.ts
@@ -1561,6 +1561,7 @@ export class ManifestGenerator {
       // merging their columns onto a descendant would generate the wrong
       // schema.
       const mergedFields: Record<string, FieldDefinition> = {};
+      const mergedFieldOwners = new Map<string, string>();
       const mergedMethods: Record<string, MethodDefinition> = {};
 
       for (const ancestorName of inheritanceChain) {
@@ -1573,15 +1574,29 @@ export class ManifestGenerator {
           continue;
         }
 
-        // Merge fields (child fields override parent fields with same name)
+        // Keep the oldest concrete STI declaration, but let a concrete class
+        // replace a framework abstract default. For example, Event refines
+        // SmrtHierarchical.parentId with its relationship target and an
+        // engine-scoped physical constraint. The local child's own fields are
+        // still applied after this loop.
         for (const [fieldName, fieldDef] of Object.entries(ancestor.fields)) {
-          if (!mergedFields[fieldName]) {
+          const existingOwner = mergedFieldOwners.get(fieldName);
+          const replacesFrameworkDefault =
+            existingOwner !== undefined &&
+            FRAMEWORK_ABSTRACT_BASE_NAMES.has(
+              this.simpleClassName(existingOwner),
+            ) &&
+            !FRAMEWORK_ABSTRACT_BASE_NAMES.has(
+              this.simpleClassName(ancestorName),
+            );
+          if (!existingOwner || replacesFrameworkDefault) {
             mergedFields[fieldName] = this.normalizeFrameworkInheritedField(
               ancestorName,
               fieldName,
               fieldDef,
               obj.className,
             );
+            mergedFieldOwners.set(fieldName, ancestorName);
           }
         }
 


### PR DESCRIPTION
## Summary

- preserve a concrete external STI ancestor's field refinement when it replaces a framework abstract default
- retain canonical `Event.parentId` relationship identity and PostgreSQL/SQLite engine allowlist for downstream STI subclasses
- add a focused `SmrtHierarchical -> Event -> Meeting` manifest/schema regression while preserving abstract-only normalization and child-own precedence

## Why

SMRT v0.43.1 still regenerated downstream `Meeting` manifests with an unscoped DuckDB self-foreign-key because `SmrtHierarchical.parentId` occupied the inherited field slot before the nearer concrete `Event.parentId` refinement was considered. This keeps the fix framework-owned and avoids downstream manifest overrides or compatibility shims.

## Validation

- Node 24.18.0 / pnpm 11.13.0
- core scanner/schema: 146 tests passed
- adjacent inheritance/generator suites: 97 tests passed
- Event DuckDB-backed JSON hierarchy: 1 test passed
- `@happyvertical/smrt-core` typecheck
- `@happyvertical/smrt-events` typecheck and Svelte check: 0 errors, 0 warnings
- core/events dependency builds
- strict knowledge check and Biome format check
- high-risk preliminary review: codex-terra CLEAR, claude-sonnet CLEAR
- high-risk final review: codex-sol CLEAR, claude-fable CLEAR
- dedicated exact-head QA: PASS

## Downstream

Blocks final validation of `anytown/anytown.ai#951`; downstream must consume the next aligned published release. No Anytown shim is included.

Closes #2504

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-issue-2504-20260825T0405Z",
  "issue": 2504,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "Node 24.18 core scanner/schema: 146 tests",
    "adjacent inheritance/generator: 97 tests",
    "Event JSON hierarchy: 1 test",
    "core/events typecheck and dependency build",
    "strict knowledge and format checks",
    "high-risk two-family preliminary and final review",
    "dedicated exact-head QA"
  ]
}
```
