### PR TITLE
feat(agents): publish principal-bound report tools

### DIFF
--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -163,6 +163,37 @@ authenticated/delegated principal and detailed server-side error. Hidden field
 request failures also use a stable public error. Tool arguments never contain
 principal or tenant authority.
 
+## Report Data-Surface Tools (issue #2462)
+
+`createReportDataSurfaceTools()` maps server-owned report definitions into the
+generic `data.discover`, `data.inspect`, and `data.query` catalog, and adds
+principal-bound `reports.query`, `reports.refresh`, `reports.drilldown`, and
+`reports.export` tools. It reuses the reports package's materialized-query,
+lifecycle, drilldown, and snapshot contracts rather than reimplementing them.
+Report ids, collections, query seams, browser delivery, background queues, and
+action hosts come only from the configured server catalog; tool arguments never
+carry principal, tenant, or report-constructor authority.
+
+- Generic discovery excludes sensitive and permission-gated report columns.
+- Discovered report fields retain safe `kind`, `filterScope`, and capability
+  metadata, while the surface reports its available actions and lifecycle
+  freshness support. Actions are filtered by the current tool allow-list and
+  effective permissions. This lets agents distinguish dimensions/buckets
+  (`where`) from measures (`having`) without exposing hidden columns or
+  authority.
+- Silent reads do not change browser state; visible reads require a host's exact
+  acknowledged revision; background requests contain no principal or tenant
+  payload.
+- Read results request the tenant-safe report lifecycle whenever an
+  authenticated database is available, so `freshness` and the redacted
+  lifecycle state cover stale and lock-skipped materializations.
+- Refresh and export use app-owned action hosts for live authorization and
+  auditing. Export captures an opaque immutable snapshot and preserves the
+  reports package's preview/confirmation protocol.
+- Drilldown re-reads a single accessible materialized row before it builds the
+  inherited source query, so callers cannot inject row values from another
+  tenant.
+
 ## Agent Orchestration (issue #1892) — invoke-agent + principal delegation
 
 A conversational (orchestrator) agent can invoke worker agents with **principal delegation**. This is *not* a new engine — it is a standard `invoke-agent` tool plus a completion-dispatch convention on top of `executeAsPrincipal` + the DispatchBus.
@@ -190,6 +221,7 @@ const tool = createInvokeAgentTool({
 |------|---------|
 | `src/agent.ts` | Base Agent class — lifecycle, dispatch, interests, config, opt-in learning trait, multi-instance identity |
 | `src/execute-as-principal.ts` | `executeAsPrincipal` / `PrincipalRun` — run agent work as a persona's bound user (#1888) |
+| `src/report-data-surface.ts` | Principal-bound report discovery, query, lifecycle, drilldown, and export tools (#2462) |
 | `src/delegation.ts` | `DelegationEnvelope` — immutable principal + bounded delegation depth (#1892) |
 | `src/invoke-agent.ts` | `invoke-agent` tool, worker executor, completion-dispatch convention, transports (#1892) |
 | `src/learning.ts` | `AgentLearningConfig` + `resolveAgentLearning()` declaration normalisation |

--- a/packages/agents/AGENTS.md
+++ b/packages/agents/AGENTS.md
@@ -181,8 +181,9 @@ carry principal, tenant, or report-constructor authority.
   effective permissions. This lets agents distinguish dimensions/buckets
   (`where`) from measures (`having`) without exposing hidden columns or
   authority.
-- Silent reads do not change browser state; visible reads require a host's exact
-  acknowledged revision; background requests contain no principal or tenant
+- Silent reads do not change browser state; visible reads require a host-bound
+  acknowledgement whose post-command revision is not older than the requested
+  compare-and-swap revision; background requests contain no principal or tenant
   payload.
 - Read results request the tenant-safe report lifecycle whenever an
   authenticated database is available, so `freshness` and the redacted

--- a/packages/agents/README.md
+++ b/packages/agents/README.md
@@ -137,6 +137,24 @@ such as `MessagingSettingsService`.
 | `AsyncQualifierFn` | Async post-filter qualifier type |
 | `QueryFn` | Query function type |
 | `AgentWithInterestsOptions` | Agent options with interests |
+| `createReportDataSurfaceTools` | Principal-bound report discovery, query, lifecycle, drilldown, and export tools |
+| `ReportDataSurfaceToolsOptions` | Server-owned report catalog and application-host seams |
+
+### Report Data-Surface Tools
+
+`createReportDataSurfaceTools()` combines the generic read-only data-surface
+tools with `reports.query`, `reports.refresh`, `reports.drilldown`, and
+`reports.export`. Configure report constructors and all transport/action seams
+on the server. Queries inherit authority exclusively from the live
+`PrincipalRun`; visible commands require an exact browser acknowledgement, and
+refresh/export retain application-owned authorization and audit hosts.
+Discovery preserves each visible report field's kind, WHERE/HAVING filter
+scope, and capabilities, plus the currently available report actions. When an
+authenticated database is present, silent and visible reads return the
+tenant-safe lifecycle-derived freshness state (including stale or
+lock-skipped materializations). Advertised actions are filtered by the live
+principal's tool allow-list and effective permissions; action hosts still
+reauthorize before mutation.
 
 ### Server Export (`@happyvertical/smrt-agents/server`)
 

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -72,6 +72,7 @@
     "@happyvertical/files": "catalog:",
     "@happyvertical/smrt-config": "workspace:*",
     "@happyvertical/smrt-core": "workspace:*",
+    "@happyvertical/smrt-reports": "workspace:*",
     "@happyvertical/smrt-secrets": "workspace:*",
     "@happyvertical/smrt-tenancy": "workspace:*",
     "@happyvertical/smrt-types": "workspace:*",

--- a/packages/agents/src/data-surface.ts
+++ b/packages/agents/src/data-surface.ts
@@ -41,8 +41,21 @@ export const DATA_QUERY_FUNCTION_NAME = 'data-query';
 export const DEFAULT_DATA_SURFACE_DEADLINE_MS = 5_000;
 export const MAX_DATA_SURFACE_DEADLINE_MS = 30_000;
 
+/** Declarative, non-authoritative metadata that a server-owned catalog may expose. */
+export type DataSurfaceMetadataValue =
+  | string
+  | number
+  | boolean
+  | null
+  | ReadonlyArray<string | number | boolean | null>;
+
 export type DataSurfaceFieldMetadata = Readonly<
-  Record<string, string | number | boolean | null>
+  Record<string, DataSurfaceMetadataValue>
+>;
+
+/** Surface-level metadata is descriptive only; it never enters query normalization. */
+export type DataSurfaceMetadata = Readonly<
+  Record<string, DataSurfaceMetadataValue>
 >;
 
 /** A data field plus server-owned visibility policy annotations. */
@@ -67,6 +80,8 @@ export interface DataSurfaceDefinition {
   className?: string;
   label?: string;
   description?: string;
+  /** Safe catalog metadata, returned only after the read gate succeeds. */
+  metadata?: DataSurfaceMetadata;
   schema: DataSurfaceSchema;
   /** Optional surface-specific executor. */
   execute?: DataSurfaceExecutor;
@@ -292,10 +307,14 @@ function visibleSchema(
 }
 
 function descriptor(surface: DataSurfaceDefinition, schema: DataQuerySchema) {
+  const metadataByFieldId = new Map(
+    surface.schema.fields.map((field) => [field.id, field.metadata]),
+  );
   return {
     id: surface.id,
     label: surface.label ?? surface.id,
     ...(surface.description ? { description: surface.description } : {}),
+    ...(surface.metadata ? { metadata: surface.metadata } : {}),
     collection: surface.collection,
     identityField: schema.identityField,
     fields: schema.fields.map((field) => ({
@@ -305,6 +324,9 @@ function descriptor(surface: DataSurfaceDefinition, schema: DataQuerySchema) {
       sortable: field.sortable === true,
       facetable: field.facetable === true,
       filterOperators: [...(field.filterOperators ?? [])].sort(),
+      ...(metadataByFieldId.get(field.id)
+        ? { metadata: metadataByFieldId.get(field.id) }
+        : {}),
     })),
     supports: schema.supports ?? {},
     limits: {

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -199,6 +199,28 @@ export {
   resolveAgentLearning,
 } from './learning.js';
 export {
+  createReportDataSurfaceDefinition,
+  createReportDataSurfaceTools,
+  REPORT_DRILLDOWN_FUNCTION_NAME,
+  REPORT_DRILLDOWN_TOOL_SLUG,
+  REPORT_EXPORT_FUNCTION_NAME,
+  REPORT_EXPORT_TOOL_SLUG,
+  REPORT_QUERY_FUNCTION_NAME,
+  REPORT_QUERY_TOOL_SLUG,
+  REPORT_REFRESH_FUNCTION_NAME,
+  REPORT_REFRESH_TOOL_SLUG,
+  type ReportDataSurfaceAuditEntry,
+  ReportDataSurfaceConfigurationError,
+  type ReportDataSurfaceDefinition,
+  type ReportDataSurfaceExportHost,
+  type ReportDataSurfaceRefreshHost,
+  type ReportDataSurfaceToolsOptions,
+  type ReportDataSurfaceVisibleAck,
+  type ReportDataSurfaceVisibleCommand,
+  ReportDataSurfaceVisibleError,
+  type ReportDataSurfaceVisibleHost,
+} from './report-data-surface.js';
+export {
   AgentSchedule,
   AgentScheduleCollection,
   type ScheduleStatus,

--- a/packages/agents/src/report-data-surface.test.ts
+++ b/packages/agents/src/report-data-surface.test.ts
@@ -541,7 +541,7 @@ describe('principal-bound report data-surface tools', () => {
     }
   });
 
-  it('requires an exact successful browser acknowledgement and rejects stale acknowledgements', async () => {
+  it('accepts bound post-command browser acknowledgements and rejects stale or malformed acknowledgements', async () => {
     let command: Record<string, unknown> | undefined;
     const visible = {
       send: vi.fn(async (value: Record<string, unknown>) => {
@@ -550,7 +550,7 @@ describe('principal-bound report data-surface tools', () => {
           commandId: value.commandId,
           identity: value.identity,
           ok: true,
-          revision: value.expectedRevision,
+          revision: Number(value.expectedRevision) + 1,
         };
       }),
     };
@@ -565,7 +565,7 @@ describe('principal-bound report data-surface tools', () => {
         version: 1,
         requestId: 'visible-report-query',
         mode: 'rows',
-        projection: ['id'],
+        projection: ['revenue'],
       },
       execution: 'visible',
       expectedRevision: 7,
@@ -575,8 +575,17 @@ describe('principal-bound report data-surface tools', () => {
       args,
       db: undefined,
     });
-    expect(result).toMatchObject({ browser: { ok: true, revision: 7 } });
-    expect(command).toMatchObject({ expectedRevision: 7 });
+    expect(result).toMatchObject({ browser: { ok: true, revision: 8 } });
+    expect(command).toMatchObject({
+      expectedRevision: 7,
+      payload: {
+        request: {
+          projection: ['id', 'revenue'],
+          sort: [{ field: 'id', direction: 'asc' }],
+          page: { kind: 'offset', offset: 0 },
+        },
+      },
+    });
 
     visible.send = vi.fn(async (value: Record<string, unknown>) => ({
       commandId: value.commandId,
@@ -590,6 +599,22 @@ describe('principal-bound report data-surface tools', () => {
         args: {
           ...args,
           request: { ...args.request, requestId: 'stale-visible' },
+        },
+        db: undefined,
+      }),
+    ).rejects.toBeInstanceOf(ReportDataSurfaceVisibleError);
+
+    visible.send = vi.fn(async (value: Record<string, unknown>) => ({
+      commandId: value.commandId,
+      ok: true,
+      revision: 8,
+    }));
+    await expect(
+      tools.get(REPORT_QUERY_TOOL_SLUG)?.execute({
+        run,
+        args: {
+          ...args,
+          request: { ...args.request, requestId: 'malformed-visible' },
         },
         db: undefined,
       }),

--- a/packages/agents/src/report-data-surface.test.ts
+++ b/packages/agents/src/report-data-surface.test.ts
@@ -1,0 +1,744 @@
+import {
+  getTestDatabase,
+  ObjectRegistry,
+  SmrtObject,
+} from '@happyvertical/smrt-core';
+import {
+  buildReportAdapterDescriptor,
+  type ReportAdapterOptions,
+} from '@happyvertical/smrt-reports';
+import {
+  disableTenancy,
+  enableTenancy,
+  withTenant,
+} from '@happyvertical/smrt-tenancy';
+import type { SessionPermissionRuntimeContext } from '@happyvertical/smrt-users';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DATA_DISCOVER_TOOL_SLUG,
+  DATA_QUERY_TOOL_SLUG,
+} from './data-surface.js';
+import type { PrincipalRun } from './execute-as-principal.js';
+import {
+  createReportDataSurfaceTools,
+  REPORT_DRILLDOWN_TOOL_SLUG,
+  REPORT_EXPORT_TOOL_SLUG,
+  REPORT_QUERY_TOOL_SLUG,
+  REPORT_REFRESH_TOOL_SLUG,
+  ReportDataSurfaceVisibleError,
+} from './report-data-surface.js';
+
+class ReportToolsInvoice extends SmrtObject {}
+class ReportToolsReport extends SmrtObject {}
+
+async function currentReportId(
+  adapter?: ReportAdapterOptions,
+): Promise<string> {
+  return (await buildReportAdapterDescriptor(ReportToolsReport, adapter))
+    .resourceId;
+}
+
+function registerFixture(): void {
+  ObjectRegistry.registerFromManifest(
+    'ReportToolsInvoice',
+    {
+      className: 'ReportToolsInvoice',
+      fields: { tenantId: { type: 'text' } },
+      methods: {},
+      decoratorConfig: { tableName: 'report_tools_invoices' },
+      schema: {
+        tableName: 'report_tools_invoices',
+        ddl: '',
+        columns: {},
+        indexes: [],
+        version: 'test',
+      },
+    },
+    '@happyvertical/smrt-agents',
+  );
+  ObjectRegistry.registerFromManifest(
+    'ReportToolsReport',
+    {
+      className: 'ReportToolsReport',
+      fields: {
+        tenantId: {
+          type: 'text',
+          _meta: { __tenancy: { isTenantIdField: true } },
+        },
+        customerId: {
+          type: 'text',
+          _meta: {
+            __report: { kind: 'group', sourceColumn: 'customerId' },
+          },
+        },
+        revenue: {
+          type: 'decimal',
+          _meta: {
+            __report: { kind: 'aggregate', fn: 'sum', column: 'totalAmount' },
+          },
+        },
+        personalRevenue: {
+          type: 'decimal',
+          _meta: {
+            sensitivity: 'personal',
+            __report: {
+              kind: 'aggregate',
+              fn: 'sum',
+              column: 'personalRevenue',
+            },
+          },
+        },
+        hiddenRevenue: {
+          type: 'decimal',
+          _meta: {
+            sensitive: true,
+            __report: {
+              kind: 'aggregate',
+              fn: 'sum',
+              column: 'hiddenRevenue',
+            },
+          },
+        },
+        restrictedRevenue: {
+          type: 'decimal',
+          _meta: {
+            readPermission: 'reports.read-restricted',
+            __report: {
+              kind: 'aggregate',
+              fn: 'sum',
+              column: 'restrictedRevenue',
+            },
+          },
+        },
+        refreshedAt: { type: 'datetime' },
+      },
+      methods: {},
+      decoratorConfig: {
+        tableName: 'report_tools_reports',
+        tenantScoped: { field: 'tenantId', mode: 'optional' },
+        report: {
+          source: 'ReportToolsInvoice',
+          refresh: { mode: 'incremental', ttl: 60_000 },
+        },
+      },
+      schema: {
+        tableName: 'report_tools_reports',
+        ddl: '',
+        columns: {},
+        indexes: [],
+        version: 'test',
+      },
+    },
+    '@happyvertical/smrt-agents',
+  );
+}
+
+function fakeRun(
+  allowedTools: string[],
+  tenantId = 'tenant-a',
+  permissions = ['reports.read', 'reports.export'],
+): PrincipalRun {
+  return {
+    context: {
+      userId: 'report-user',
+      tenantId,
+      database: undefined,
+      permissions,
+      permissionSet: new Set(permissions),
+      membership: null,
+      postgresRls: false,
+      session: null,
+      sessionId: null,
+      superAdminBypass: false,
+      systemContext: false,
+      user: null,
+    } satisfies SessionPermissionRuntimeContext,
+    permissions,
+    allowedTools,
+    isToolAllowed: (tool) => allowedTools.includes(tool),
+    assertToolAllowed(tool) {
+      if (!allowedTools.includes(tool)) throw new Error(`denied:${tool}`);
+    },
+    async assertOperation(collection, action) {
+      if (collection !== 'reports' || action !== 'read') {
+        throw new Error('rbac denied');
+      }
+      return {
+        allowed: true,
+        permission: 'reports.read',
+        reason: 'permission_granted',
+      };
+    },
+  };
+}
+
+type ReportRow = Record<string, unknown>;
+
+function reportCollection(run: PrincipalRun): {
+  list(options: Record<string, unknown>): Promise<ReportRow[]>;
+  count(options?: Record<string, unknown>): Promise<number>;
+} {
+  const rows: ReportRow[] =
+    run.context.tenantId === 'tenant-a'
+      ? [
+          {
+            id: 'tenant-a-row',
+            tenantId: 'tenant-a',
+            customerId: 'customer-a',
+            revenue: 10,
+            personalRevenue: 2,
+          },
+        ]
+      : [
+          {
+            id: 'tenant-b-row',
+            tenantId: 'tenant-b',
+            customerId: 'customer-b',
+            revenue: 20,
+            personalRevenue: 3,
+          },
+        ];
+  return {
+    async list(options) {
+      const where = options.where;
+      if (where && JSON.stringify(where).includes('tenant-a-row')) {
+        return rows.filter((row) => row.id === 'tenant-a-row');
+      }
+      if (where && JSON.stringify(where).includes('tenant-b-row')) {
+        return rows.filter((row) => row.id === 'tenant-b-row');
+      }
+      return rows;
+    },
+    async count() {
+      return rows.length;
+    },
+  };
+}
+
+function toolSet(options: Parameters<typeof createReportDataSurfaceTools>[0]) {
+  return new Map(
+    createReportDataSurfaceTools(options).map((tool) => [tool.slug, tool]),
+  );
+}
+
+function reportDefinition(overrides: Record<string, unknown> = {}) {
+  return {
+    report: ReportToolsReport,
+    collection: 'reports',
+    query: ({ run }: { run: PrincipalRun }) => ({
+      collection: reportCollection(run),
+    }),
+    ...overrides,
+  };
+}
+
+async function setupLifecycleDb(): Promise<DatabaseInterface> {
+  const db = await getTestDatabase({
+    type: 'sqlite',
+    url: ':memory:',
+    classes: [],
+  });
+  await db.query(`
+    CREATE TABLE report_tools_reports (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT,
+      customer_id TEXT,
+      revenue REAL,
+      personal_revenue REAL,
+      refreshed_at TEXT
+    )
+  `);
+  await db.query(`
+    CREATE TABLE _smrt_report_runs (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT,
+      scope_key TEXT NOT NULL,
+      report_class TEXT NOT NULL,
+      source_class TEXT NOT NULL,
+      mode TEXT NOT NULL,
+      trigger TEXT NOT NULL,
+      status TEXT NOT NULL,
+      started_at TEXT,
+      completed_at TEXT,
+      row_count INTEGER,
+      changed_group_count INTEGER,
+      created_at TEXT
+    )
+  `);
+  await db.query(`
+    CREATE TABLE _smrt_report_locks (
+      id TEXT PRIMARY KEY,
+      tenant_id TEXT,
+      scope_key TEXT NOT NULL,
+      report_class TEXT NOT NULL,
+      owner_id TEXT,
+      expires_at TEXT
+    )
+  `);
+  await db.insert('report_tools_reports', {
+    id: 'tenant-a-row',
+    tenant_id: 'tenant-a',
+    customer_id: 'customer-a',
+    revenue: 10,
+    personal_revenue: 2,
+    refreshed_at: '2026-08-24T00:00:00.000Z',
+  });
+  return db;
+}
+
+describe('principal-bound report data-surface tools', () => {
+  beforeEach(() => {
+    ObjectRegistry.clear();
+    registerFixture();
+    enableTenancy();
+  });
+
+  afterEach(() => {
+    disableTenancy();
+    ObjectRegistry.clear();
+  });
+
+  it('discovers report fields through generic tools while hiding sensitive and restricted fields', async () => {
+    const tools = toolSet({ reports: [reportDefinition()] });
+    const run = fakeRun([DATA_DISCOVER_TOOL_SLUG, DATA_QUERY_TOOL_SLUG]);
+
+    const discovered = await tools.get(DATA_DISCOVER_TOOL_SLUG)?.execute({
+      run,
+      args: {},
+      db: undefined,
+    });
+    expect(discovered).toEqual([
+      expect.objectContaining({ id: expect.any(String) }),
+    ]);
+    const reportId = (discovered as Array<{ id: string }>)[0]?.id;
+    const fields = (
+      discovered as Array<{
+        fields: Array<{
+          id: string;
+          metadata?: Record<string, unknown>;
+        }>;
+        metadata?: Record<string, unknown>;
+      }>
+    )[0]?.fields.map((field) => field.id);
+    expect(fields).toContain('personal_revenue');
+    expect(fields).not.toContain('hidden_revenue');
+    expect(fields).not.toContain('restricted_revenue');
+    const customer = (
+      discovered as Array<{
+        fields: Array<{
+          id: string;
+          metadata?: Record<string, unknown>;
+        }>;
+      }>
+    )[0]?.fields.find((field) => field.id === 'customer_id');
+    const revenue = (
+      discovered as Array<{
+        fields: Array<{
+          id: string;
+          metadata?: Record<string, unknown>;
+        }>;
+      }>
+    )[0]?.fields.find((field) => field.id === 'revenue');
+    expect(customer?.metadata).toMatchObject({
+      kind: 'group',
+      filterScope: 'where',
+      capabilities: expect.arrayContaining(['filter']),
+    });
+    expect(revenue?.metadata).toMatchObject({
+      kind: 'aggregate',
+      filterScope: 'having',
+      capabilities: expect.arrayContaining(['filter']),
+    });
+    expect(
+      (discovered as Array<{ metadata?: Record<string, unknown> }>)[0]
+        ?.metadata,
+    ).toMatchObject({
+      surfaceKind: 'report',
+      freshnessSource: 'reportLifecycle',
+      allowedActions: expect.arrayContaining(['query']),
+    });
+
+    const result = await tools.get(DATA_QUERY_TOOL_SLUG)?.execute({
+      run,
+      args: {
+        surfaceId: reportId,
+        request: {
+          version: 1,
+          requestId: 'generic-report-query',
+          mode: 'rows',
+          projection: ['id', 'customer_id'],
+        },
+      },
+      db: undefined,
+    });
+    expect(result).toMatchObject({
+      rows: [{ id: 'tenant-a-row' }],
+    });
+  });
+
+  it('keeps silent queries local and background queries authority-free', async () => {
+    const queued: unknown[] = [];
+    const adapter = { tenantScope: 'tenant' as const };
+    const tools = toolSet({
+      reports: [
+        reportDefinition({
+          adapter,
+          enqueueBackgroundQuery: async (task, context) => {
+            queued.push({ task, context });
+            return { taskId: 'report-job-1' };
+          },
+        }),
+      ],
+    });
+    const run = fakeRun([REPORT_QUERY_TOOL_SLUG]);
+    const reportId = await currentReportId(adapter);
+    const request = {
+      version: 1 as const,
+      requestId: 'silent-report-query',
+      mode: 'rows' as const,
+      projection: ['id'],
+    };
+    const silent = await tools.get(REPORT_QUERY_TOOL_SLUG)?.execute({
+      run,
+      args: { reportId, request, execution: 'silent' },
+      db: undefined,
+    });
+    expect(silent).toMatchObject({
+      execution: 'silent',
+      rows: [{ id: 'tenant-a-row' }],
+    });
+
+    const background = await tools.get(REPORT_QUERY_TOOL_SLUG)?.execute({
+      run,
+      args: { reportId, request, execution: 'background' },
+      db: undefined,
+    });
+    expect(background).toMatchObject({
+      execution: 'background',
+      status: 'queued',
+      taskId: 'report-job-1',
+    });
+    expect(queued).toHaveLength(1);
+    expect(queued[0]).toMatchObject({
+      task: {
+        execution: 'background',
+        resourceId: reportId,
+        inherits: ['principal', 'tenant', 'report-definition', 'field-policy'],
+      },
+      context: { run },
+    });
+    expect(JSON.stringify(queued[0]?.task)).not.toContain('tenant-a');
+    expect(JSON.stringify(queued[0]?.task)).not.toContain('report-user');
+  });
+
+  it('does not advertise actions that the principal lacks permission to use', async () => {
+    const tools = toolSet({
+      reports: [
+        reportDefinition({
+          adapter: { refreshPermission: 'reports.refresh-sensitive' },
+          refresh: {
+            actionHost: () => ({ authorize: vi.fn(), audit: vi.fn() }),
+          },
+          export: {
+            captureSnapshot: async () => ({ id: 'snapshot-a' }),
+            actionHost: () => ({
+              assertSnapshot: vi.fn(),
+              authorize: vi.fn(),
+              audit: vi.fn(),
+            }),
+          },
+        }),
+      ],
+    });
+    const run = fakeRun(
+      [
+        DATA_DISCOVER_TOOL_SLUG,
+        REPORT_REFRESH_TOOL_SLUG,
+        REPORT_EXPORT_TOOL_SLUG,
+      ],
+      'tenant-a',
+      ['reports.read'],
+    );
+
+    const discovered = await tools.get(DATA_DISCOVER_TOOL_SLUG)?.execute({
+      run,
+      args: {},
+      db: undefined,
+    });
+    const metadata = (
+      discovered as Array<{ metadata?: Record<string, unknown> }>
+    )[0]?.metadata;
+    expect(metadata?.allowedActions).not.toContain('refresh');
+    expect(metadata?.allowedActions).not.toContain('export');
+    expect(metadata?.allowedActions).not.toContain('query');
+    expect(metadata?.queryModes).toEqual([]);
+    expect(metadata).not.toHaveProperty('refreshRequiredPermission');
+  });
+
+  it('discloses stale and lock-skipped lifecycle state through report queries', async () => {
+    const db = await setupLifecycleDb();
+    const tools = toolSet({ reports: [reportDefinition()] });
+    const run = fakeRun([REPORT_QUERY_TOOL_SLUG]);
+    const reportId = await currentReportId();
+    const args = {
+      reportId,
+      execution: 'silent',
+      request: {
+        version: 1,
+        requestId: 'report-lifecycle-read',
+        mode: 'rows',
+        projection: ['id'],
+      },
+    };
+    try {
+      const stale = await withTenant({ tenantId: 'tenant-a' }, () =>
+        tools.get(REPORT_QUERY_TOOL_SLUG)?.execute({ run, args, db }),
+      );
+      expect(stale).toMatchObject({
+        freshness: { state: 'stale' },
+        reportLifecycle: { snapshot: { state: 'stale' } },
+      });
+
+      const descriptor = await buildReportAdapterDescriptor(ReportToolsReport);
+      await db.insert('_smrt_report_runs', {
+        id: 'lock-skipped-run',
+        tenant_id: 'tenant-a',
+        scope_key: 'tenant:tenant-a',
+        report_class: descriptor.reportClassName,
+        source_class: descriptor.sourceClassName,
+        mode: 'incremental',
+        trigger: 'manual',
+        status: 'skipped',
+        started_at: '2026-08-24T00:00:00.000Z',
+        completed_at: '2026-08-24T00:00:01.000Z',
+        row_count: 1,
+        changed_group_count: 0,
+        created_at: '2026-08-24T00:00:01.000Z',
+      });
+      const lockSkipped = await withTenant({ tenantId: 'tenant-a' }, () =>
+        tools.get(REPORT_QUERY_TOOL_SLUG)?.execute({
+          run,
+          args: {
+            ...args,
+            request: { ...args.request, requestId: 'lock-skipped-read' },
+          },
+          db,
+        }),
+      );
+      expect(lockSkipped).toMatchObject({
+        freshness: { state: 'stale' },
+        reportLifecycle: {
+          snapshot: { state: 'lock-skipped', run: { status: 'skipped' } },
+        },
+      });
+    } finally {
+      if (typeof db.close === 'function') await db.close();
+    }
+  });
+
+  it('requires an exact successful browser acknowledgement and rejects stale acknowledgements', async () => {
+    let command: Record<string, unknown> | undefined;
+    const visible = {
+      send: vi.fn(async (value: Record<string, unknown>) => {
+        command = value;
+        return {
+          commandId: value.commandId,
+          identity: value.identity,
+          ok: true,
+          revision: value.expectedRevision,
+        };
+      }),
+    };
+    const tools = toolSet({
+      reports: [reportDefinition({ visible })],
+    });
+    const run = fakeRun([REPORT_QUERY_TOOL_SLUG]);
+    const reportId = await currentReportId();
+    const args = {
+      reportId,
+      request: {
+        version: 1,
+        requestId: 'visible-report-query',
+        mode: 'rows',
+        projection: ['id'],
+      },
+      execution: 'visible',
+      expectedRevision: 7,
+    };
+    const result = await tools.get(REPORT_QUERY_TOOL_SLUG)?.execute({
+      run,
+      args,
+      db: undefined,
+    });
+    expect(result).toMatchObject({ browser: { ok: true, revision: 7 } });
+    expect(command).toMatchObject({ expectedRevision: 7 });
+
+    visible.send = vi.fn(async (value: Record<string, unknown>) => ({
+      commandId: value.commandId,
+      identity: value.identity,
+      ok: true,
+      revision: 6,
+    }));
+    await expect(
+      tools.get(REPORT_QUERY_TOOL_SLUG)?.execute({
+        run,
+        args: {
+          ...args,
+          request: { ...args.request, requestId: 'stale-visible' },
+        },
+        db: undefined,
+      }),
+    ).rejects.toBeInstanceOf(ReportDataSurfaceVisibleError);
+  });
+
+  it('only resolves drilldown from the current tenant materialized row', async () => {
+    const tools = toolSet({ reports: [reportDefinition()] });
+    const drilldown = tools.get(REPORT_DRILLDOWN_TOOL_SLUG);
+    const tenantA = fakeRun([REPORT_DRILLDOWN_TOOL_SLUG], 'tenant-a');
+    const tenantB = fakeRun([REPORT_DRILLDOWN_TOOL_SLUG], 'tenant-b');
+    const reportId = await currentReportId();
+
+    const handoff = await drilldown?.execute({
+      run: tenantA,
+      args: { reportId, rowId: 'tenant-a-row' },
+      db: undefined,
+    });
+    expect(handoff).toMatchObject({
+      resourceId: reportId,
+      sourceClassName: expect.stringContaining('ReportToolsInvoice'),
+      constraints: [
+        expect.objectContaining({ id: 'customer_id', value: 'customer-a' }),
+      ],
+    });
+
+    await expect(
+      drilldown?.execute({
+        run: tenantB,
+        args: { reportId, rowId: 'tenant-a-row' },
+        db: undefined,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('forwards the report-declared refresh permission to the live action host', async () => {
+    const db = await setupLifecycleDb();
+    const authorize = vi.fn();
+    const audit = vi.fn();
+    const adapter = { refreshPermission: 'reports.refresh-sensitive' };
+    const tools = toolSet({
+      reports: [
+        reportDefinition({
+          adapter,
+          refresh: { actionHost: () => ({ authorize, audit }) },
+        }),
+      ],
+    });
+    const run = fakeRun([REPORT_REFRESH_TOOL_SLUG]);
+    try {
+      await expect(
+        withTenant({ tenantId: 'tenant-a' }, async () =>
+          tools.get(REPORT_REFRESH_TOOL_SLUG)?.execute({
+            run,
+            args: {
+              reportId: await currentReportId(adapter),
+              phase: 'preview',
+              mode: 'invalid',
+            },
+            db,
+          }),
+        ),
+      ).rejects.toThrow('Report refresh mode is invalid');
+      expect(authorize).not.toHaveBeenCalled();
+      await withTenant({ tenantId: 'tenant-a' }, async () =>
+        tools.get(REPORT_REFRESH_TOOL_SLUG)?.execute({
+          run,
+          args: {
+            reportId: await currentReportId(adapter),
+            phase: 'preview',
+          },
+          db,
+        }),
+      );
+      expect(authorize).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requiredPermission: 'reports.refresh-sensitive',
+        }),
+      );
+      expect(audit).toHaveBeenCalledTimes(1);
+    } finally {
+      if (typeof db.close === 'function') await db.close();
+    }
+  });
+
+  it('requires snapshot/auth/audit and explicit confirmation for sensitive exports', async () => {
+    const db = await setupLifecycleDb();
+    const captured: unknown[] = [];
+    const authorize = vi.fn();
+    const audit = vi.fn();
+    const assertSnapshot = vi.fn();
+    const definition = reportDefinition({
+      export: {
+        captureSnapshot: async (context: unknown) => {
+          captured.push(context);
+          return { id: 'snapshot-a' };
+        },
+        actionHost: () => ({ assertSnapshot, authorize, audit }),
+      },
+    });
+    const tools = toolSet({ reports: [definition] });
+    const run = fakeRun([REPORT_EXPORT_TOOL_SLUG]);
+    const reportId = await currentReportId();
+    const args = {
+      reportId,
+      phase: 'apply',
+      query: {
+        version: 1,
+        requestId: 'sensitive-export',
+        mode: 'rows',
+        projection: ['id', 'personal_revenue'],
+      },
+      format: 'csv',
+    };
+    try {
+      await expect(
+        withTenant({ tenantId: 'tenant-a' }, () =>
+          tools.get(REPORT_EXPORT_TOOL_SLUG)?.execute({
+            run,
+            args,
+            db,
+          }),
+        ),
+      ).rejects.toThrow(
+        'Sensitive report exports require explicit confirmation',
+      );
+      expect(captured).toHaveLength(1);
+      expect(authorize).not.toHaveBeenCalled();
+      expect(assertSnapshot).not.toHaveBeenCalled();
+      expect(audit).not.toHaveBeenCalled();
+
+      const applied = await withTenant({ tenantId: 'tenant-a' }, () =>
+        tools.get(REPORT_EXPORT_TOOL_SLUG)?.execute({
+          run,
+          args: { ...args, confirmed: true },
+          db,
+        }),
+      );
+      expect(applied).toMatchObject({
+        phase: 'apply',
+        execution: 'stream',
+        status: 'ready',
+      });
+      expect(authorize).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requiredPermission: 'reports.export',
+          confirmationRequired: true,
+        }),
+      );
+      expect(assertSnapshot).toHaveBeenCalledTimes(1);
+      expect(audit).toHaveBeenCalledTimes(1);
+    } finally {
+      if (typeof db.close === 'function') await db.close();
+    }
+  });
+});

--- a/packages/agents/src/report-data-surface.test.ts
+++ b/packages/agents/src/report-data-surface.test.ts
@@ -593,7 +593,8 @@ describe('principal-bound report data-surface tools', () => {
   });
 
   it('only resolves drilldown from the current tenant materialized row', async () => {
-    const tools = toolSet({ reports: [reportDefinition()] });
+    const audit = vi.fn();
+    const tools = toolSet({ reports: [reportDefinition()], audit });
     const drilldown = tools.get(REPORT_DRILLDOWN_TOOL_SLUG);
     const tenantA = fakeRun([REPORT_DRILLDOWN_TOOL_SLUG], 'tenant-a');
     const tenantB = fakeRun([REPORT_DRILLDOWN_TOOL_SLUG], 'tenant-b');
@@ -611,6 +612,12 @@ describe('principal-bound report data-surface tools', () => {
         expect.objectContaining({ id: 'customer_id', value: 'customer-a' }),
       ],
     });
+    expect(audit).toHaveBeenCalledWith({
+      action: 'drilldown',
+      reportId,
+      userId: 'report-user',
+      tenantId: 'tenant-a',
+    });
 
     await expect(
       drilldown?.execute({
@@ -619,6 +626,22 @@ describe('principal-bound report data-surface tools', () => {
         db: undefined,
       }),
     ).rejects.toThrow();
+  });
+
+  it('fails closed when drilldown has no live audit sink', async () => {
+    const tools = toolSet({ reports: [reportDefinition()] });
+    const drilldown = tools.get(REPORT_DRILLDOWN_TOOL_SLUG);
+
+    await expect(
+      drilldown?.execute({
+        run: fakeRun([REPORT_DRILLDOWN_TOOL_SLUG]),
+        args: {
+          reportId: await currentReportId(),
+          rowId: 'tenant-a-row',
+        },
+        db: undefined,
+      }),
+    ).rejects.toThrow('Report drilldown requires a live audit sink');
   });
 
   it('forwards the report-declared refresh permission to the live action host', async () => {

--- a/packages/agents/src/report-data-surface.test.ts
+++ b/packages/agents/src/report-data-surface.test.ts
@@ -358,6 +358,10 @@ describe('principal-bound report data-surface tools', () => {
       freshnessSource: 'reportLifecycle',
       allowedActions: expect.arrayContaining(['query']),
     });
+    expect(
+      (discovered as Array<{ metadata?: { allowedActions?: string[] } }>)[0]
+        ?.metadata?.allowedActions,
+    ).not.toContain('drilldown');
 
     const result = await tools.get(DATA_QUERY_TOOL_SLUG)?.execute({
       run,
@@ -599,6 +603,15 @@ describe('principal-bound report data-surface tools', () => {
     const tenantA = fakeRun([REPORT_DRILLDOWN_TOOL_SLUG], 'tenant-a');
     const tenantB = fakeRun([REPORT_DRILLDOWN_TOOL_SLUG], 'tenant-b');
     const reportId = await currentReportId();
+    const discovered = await tools.get(DATA_DISCOVER_TOOL_SLUG)?.execute({
+      run: fakeRun([DATA_DISCOVER_TOOL_SLUG, REPORT_DRILLDOWN_TOOL_SLUG]),
+      args: {},
+      db: undefined,
+    });
+    expect(
+      (discovered as Array<{ metadata?: { allowedActions?: string[] } }>)[0]
+        ?.metadata?.allowedActions,
+    ).toContain('drilldown');
 
     const handoff = await drilldown?.execute({
       run: tenantA,

--- a/packages/agents/src/report-data-surface.ts
+++ b/packages/agents/src/report-data-surface.ts
@@ -676,6 +676,11 @@ export function createReportDataSurfaceTools(
     },
     async ({ run, args, db }) => {
       run.assertToolAllowed(REPORT_DRILLDOWN_TOOL_SLUG);
+      if (typeof options.audit !== 'function') {
+        throw new ReportDataSurfaceConfigurationError(
+          'Report drilldown requires a live audit sink',
+        );
+      }
       const { definition, descriptor } = await reportEntry(
         options,
         run,

--- a/packages/agents/src/report-data-surface.ts
+++ b/packages/agents/src/report-data-surface.ts
@@ -9,7 +9,10 @@
 
 import { randomUUID } from 'node:crypto';
 import type { AITool } from '@happyvertical/ai';
-import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+import {
+  normalizeDataQueryRequest,
+  type SmrtClassOptions,
+} from '@happyvertical/smrt-core';
 import {
   type AppliedReportExport,
   type AppliedReportRefresh,
@@ -458,15 +461,29 @@ async function dataSurfaceCatalog(
 }
 
 function commandResultIsBound(
-  ack: ReportDataSurfaceVisibleAck,
+  ack: unknown,
   command: ReportDataSurfaceVisibleCommand,
-): boolean {
+): ack is ReportDataSurfaceVisibleAck {
+  if (typeof ack !== 'object' || ack === null) return false;
+  const value = ack as Record<string, unknown>;
+  if (typeof value.identity !== 'object' || value.identity === null) {
+    return false;
+  }
+  const identity = value.identity as Record<string, unknown>;
   return (
-    ack.commandId === command.commandId &&
-    ack.identity.surfaceId === command.identity.surfaceId &&
-    ack.identity.kind === command.identity.kind &&
-    ack.revision === command.expectedRevision
+    value.commandId === command.commandId &&
+    identity.surfaceId === command.identity.surfaceId &&
+    identity.kind === command.identity.kind &&
+    typeof value.revision === 'number' &&
+    Number.isSafeInteger(value.revision) &&
+    value.revision >= command.expectedRevision
   );
+}
+
+function commandFailureReason(ack: unknown): string | undefined {
+  if (typeof ack !== 'object' || ack === null) return undefined;
+  const reason = (ack as Record<string, unknown>).reason;
+  return typeof reason === 'string' ? reason : undefined;
 }
 
 function lifecycleOptions(
@@ -512,6 +529,10 @@ export function createReportDataSurfaceTools(
         run,
         args.reportId,
       );
+      const request = normalizeDataQueryRequest(
+        args.request,
+        descriptor.schema,
+      );
       let execution: 'silent' | 'background' | 'visible' = 'silent';
       if (args.execution !== undefined) {
         if (
@@ -546,7 +567,7 @@ export function createReportDataSurfaceTools(
         }
         const result = await queryReportMaterializedRows(
           definition.report,
-          args.request,
+          request,
           {
             ...base,
             adapter: definition.adapter,
@@ -566,12 +587,12 @@ export function createReportDataSurfaceTools(
 
       const result =
         execution === 'silent'
-          ? await queryReportMaterializedRows(definition.report, args.request, {
+          ? await queryReportMaterializedRows(definition.report, request, {
               ...base,
               adapter: definition.adapter,
               execution: 'silent',
             })
-          : await queryReportMaterializedRows(definition.report, args.request, {
+          : await queryReportMaterializedRows(definition.report, request, {
               ...base,
               adapter: definition.adapter,
               execution: 'visible',
@@ -602,11 +623,16 @@ export function createReportDataSurfaceTools(
         identity: { surfaceId: descriptor.resourceId, kind: 'report' },
         expectedRevision,
         controlId: 'query',
-        payload: { request: args.request as DataQueryRequest },
+        payload: { request },
       };
       const acknowledged = await definition.visible.send(command, { run });
-      if (!commandResultIsBound(acknowledged, command) || !acknowledged.ok) {
-        throw new ReportDataSurfaceVisibleError(acknowledged.reason);
+      if (
+        !commandResultIsBound(acknowledged, command) ||
+        acknowledged.ok !== true
+      ) {
+        throw new ReportDataSurfaceVisibleError(
+          commandFailureReason(acknowledged),
+        );
       }
       await audit(options, 'query', descriptor.resourceId, run);
       return { ...result, browser: acknowledged };

--- a/packages/agents/src/report-data-surface.ts
+++ b/packages/agents/src/report-data-surface.ts
@@ -1,0 +1,805 @@
+/**
+ * Principal-bound report tools built on the shared data-surface contracts.
+ *
+ * Reports remain the authority for materialized queries, lifecycle, drilldown,
+ * and export validation. This module only binds those contracts to a live
+ * PrincipalRun and the generic data-surface catalog. Applications retain
+ * authorization, audit, queue, immutable-snapshot, and browser transports.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { AITool } from '@happyvertical/ai';
+import type { SmrtClassOptions } from '@happyvertical/smrt-core';
+import {
+  type AppliedReportExport,
+  type AppliedReportRefresh,
+  applyReportExport,
+  applyReportRefresh,
+  buildReportAdapterDescriptor,
+  buildReportDrilldownQuery,
+  createReportExportRequest,
+  createReportExportSnapshot,
+  previewReportExport,
+  previewReportRefresh,
+  queryReportMaterializedRows,
+  type ReportAdapterDescriptor,
+  type ReportAdapterOptions,
+  type ReportBackgroundQueryTask,
+  type ReportDataQueryResult,
+  type ReportExportActionHost,
+  type ReportExportPreview,
+  type ReportExportSnapshotBinding,
+  type ReportLifecycleOptions,
+  type ReportQueryOptions,
+  type ReportRefreshActionHost,
+  type ReportRefreshPreview,
+} from '@happyvertical/smrt-reports';
+import type { DataQueryRequest } from '@happyvertical/smrt-types';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import {
+  createDataSurfaceTools,
+  DATA_QUERY_TOOL_SLUG,
+  type DataSurfaceDefinition,
+  DataSurfaceDeniedError,
+  type DataSurfaceExecutionContext,
+  type DataSurfaceSchema,
+  type DataSurfaceToolsOptions,
+} from './data-surface.js';
+import type { PrincipalRun } from './execute-as-principal.js';
+import type { PrincipalTool, PrincipalToolContext } from './invoke-agent.js';
+
+export const REPORT_QUERY_TOOL_SLUG = 'reports.query';
+export const REPORT_REFRESH_TOOL_SLUG = 'reports.refresh';
+export const REPORT_DRILLDOWN_TOOL_SLUG = 'reports.drilldown';
+export const REPORT_EXPORT_TOOL_SLUG = 'reports.export';
+
+export const REPORT_QUERY_FUNCTION_NAME = 'reports-query';
+export const REPORT_REFRESH_FUNCTION_NAME = 'reports-refresh';
+export const REPORT_DRILLDOWN_FUNCTION_NAME = 'reports-drilldown';
+export const REPORT_EXPORT_FUNCTION_NAME = 'reports-export';
+
+type ReportCtor = Parameters<typeof buildReportAdapterDescriptor>[0];
+type ReportReadOptions = Omit<
+  ReportQueryOptions,
+  'adapter' | 'db' | 'execution'
+>;
+
+/** A server-authenticated browser command compatible with the chat bridge. */
+export interface ReportDataSurfaceVisibleCommand {
+  version: 1;
+  commandId: string;
+  identity: { surfaceId: string; kind: 'report' };
+  expectedRevision: number;
+  controlId: 'query';
+  payload: { request: DataQueryRequest };
+}
+
+/** Browser acknowledgement is required before a visible query succeeds. */
+export interface ReportDataSurfaceVisibleAck {
+  commandId: string;
+  identity: { surfaceId: string; kind: 'report' };
+  ok: boolean;
+  revision?: number;
+  reason?: string;
+}
+
+export interface ReportDataSurfaceVisibleHost {
+  /**
+   * The host must bind the command to an authenticated browser session and
+   * await its acknowledgement. It must not use this command as authorization.
+   */
+  send(
+    command: ReportDataSurfaceVisibleCommand,
+    context: { run: PrincipalRun },
+  ): Promise<ReportDataSurfaceVisibleAck>;
+}
+
+export interface ReportDataSurfaceExportHost {
+  /** The host captures an opaque immutable materialization binding. */
+  captureSnapshot(context: {
+    run: PrincipalRun;
+    descriptor: ReportAdapterDescriptor;
+    result: ReportDataQueryResult;
+  }): Promise<ReportExportSnapshotBinding>;
+  /** The returned host owns current authorization, audit, and queueing. */
+  actionHost(context: {
+    run: PrincipalRun;
+  }): ReportExportActionHost | Promise<ReportExportActionHost>;
+}
+
+export interface ReportDataSurfaceRefreshHost {
+  /** The returned host authorizes and audits against the live principal. */
+  actionHost(context: {
+    run: PrincipalRun;
+  }): ReportRefreshActionHost | Promise<ReportRefreshActionHost>;
+  /** Optional queue tuning that remains application-owned. */
+  options?: Omit<
+    Parameters<typeof applyReportRefresh>[1],
+    'db' | 'host' | 'mode' | 'refreshAction'
+  >;
+}
+
+export interface ReportDataSurfaceDefinition {
+  /** Report model; never supplied by a model or browser argument. */
+  report: ReportCtor;
+  /** Permission-catalog collection used for the shared read gate. */
+  collection: string;
+  label?: string;
+  description?: string;
+  adapter?: ReportAdapterOptions;
+  /** Application-owned collection/lifecycle seam for materialized reads. */
+  query?: (
+    context: DataSurfaceExecutionContext,
+  ) => ReportReadOptions | Promise<ReportReadOptions>;
+  /** Background execution never receives principal or tenant in its task. */
+  enqueueBackgroundQuery?: (
+    task: ReportBackgroundQueryTask,
+    context: { run: PrincipalRun },
+  ) => Promise<{ taskId: string }>;
+  visible?: ReportDataSurfaceVisibleHost;
+  refresh?: ReportDataSurfaceRefreshHost;
+  export?: ReportDataSurfaceExportHost;
+}
+
+export interface ReportDataSurfaceAuditEntry {
+  action: 'query' | 'refresh' | 'drilldown' | 'export';
+  reportId: string;
+  userId: string;
+  tenantId: string | null;
+}
+
+export interface ReportDataSurfaceToolsOptions {
+  reports:
+    | readonly ReportDataSurfaceDefinition[]
+    | ((
+        run: PrincipalRun,
+      ) =>
+        | readonly ReportDataSurfaceDefinition[]
+        | Promise<readonly ReportDataSurfaceDefinition[]>);
+  /** Optional audit of agent-level handoffs; report action hosts audit mutations. */
+  audit?: (entry: ReportDataSurfaceAuditEntry) => void | Promise<void>;
+  /** Passed through to generic data.discover/data.inspect/data.query tools. */
+  dataSurface?: Omit<DataSurfaceToolsOptions, 'surfaces' | 'execute' | 'audit'>;
+}
+
+export class ReportDataSurfaceVisibleError extends Error {
+  constructor(reason?: string) {
+    super(
+      `Report visible command was not acknowledged${reason ? `: ${reason}` : ''}`,
+    );
+    this.name = 'ReportDataSurfaceVisibleError';
+  }
+}
+
+export class ReportDataSurfaceConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ReportDataSurfaceConfigurationError';
+  }
+}
+
+function requiredString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new ReportDataSurfaceConfigurationError(
+      `${label} must be a non-empty string`,
+    );
+  }
+  return value;
+}
+
+function principalFromRun(
+  run: PrincipalRun,
+): DataSurfaceExecutionContext['principal'] {
+  const userId = run.context.userId;
+  if (!userId) throw new DataSurfaceDeniedError();
+  return { userId, tenantId: run.context.tenantId };
+}
+
+function reportDatabase(
+  run: PrincipalRun,
+  fallback: PrincipalToolContext['db'],
+): DatabaseInterface | undefined {
+  const database = run.context.database ?? fallback;
+  if (database === undefined) return undefined;
+  if (
+    typeof database !== 'object' ||
+    database === null ||
+    !('query' in database) ||
+    typeof database.query !== 'function'
+  ) {
+    throw new ReportDataSurfaceConfigurationError(
+      'Report tools require a live database handle, not a database configuration',
+    );
+  }
+  return database as DatabaseInterface;
+}
+
+function requireDatabase(
+  run: PrincipalRun,
+  fallback: PrincipalToolContext['db'],
+): DatabaseInterface {
+  const database = reportDatabase(run, fallback);
+  if (!database) {
+    throw new ReportDataSurfaceConfigurationError(
+      'Report lifecycle and export tools require the authenticated database context',
+    );
+  }
+  return database;
+}
+
+function querySchema(descriptor: ReportAdapterDescriptor): DataSurfaceSchema {
+  return {
+    ...descriptor.schema,
+    fields: descriptor.columns.map((column) => ({
+      id: column.id,
+      type: column.type,
+      projectable: column.projectable !== false,
+      sortable: column.sortable === true,
+      facetable: column.facetable === true,
+      ...(column.filterOperators
+        ? { filterOperators: [...column.filterOperators] }
+        : {}),
+      metadata: {
+        kind: column.kind,
+        filterScope: column.filterScope,
+        capabilities: [...column.capabilities],
+        ...(column.bucket ? { bucket: column.bucket } : {}),
+        ...(column.aggregate ? { aggregate: column.aggregate } : {}),
+        ...(column.format ? { format: column.format } : {}),
+      },
+      // The report descriptor is fail-closed: sensitive and permissioned
+      // fields were already removed before reaching this catalog.
+    })),
+  };
+}
+
+function reportCatalogMetadata(
+  definition: ReportDataSurfaceDefinition,
+  descriptor: ReportAdapterDescriptor,
+  run?: PrincipalRun,
+): NonNullable<DataSurfaceDefinition['metadata']> {
+  const canUse = (tool: string) => run?.isToolAllowed(tool) ?? true;
+  const canUseAction = (tool: string, requiredPermission: string) =>
+    canUse(tool) && (run?.permissions.includes(requiredPermission) ?? true);
+  const canQuery =
+    canUse(DATA_QUERY_TOOL_SLUG) || canUse(REPORT_QUERY_TOOL_SLUG);
+  const queryModes = descriptor.queryExecution.modes.filter(
+    (mode) =>
+      (mode === 'silent' && canQuery) ||
+      (mode === 'background' &&
+        definition.enqueueBackgroundQuery !== undefined &&
+        canUse(REPORT_QUERY_TOOL_SLUG)) ||
+      (mode === 'visible' &&
+        definition.visible !== undefined &&
+        canUse(REPORT_QUERY_TOOL_SLUG)),
+  );
+  const allowedActions = [
+    ...(canQuery ? ['query'] : []),
+    ...(definition.refresh &&
+    canUseAction(
+      REPORT_REFRESH_TOOL_SLUG,
+      descriptor.refresh.action.requiredPermission,
+    )
+      ? [descriptor.refresh.action.id]
+      : []),
+    ...(canUse(REPORT_DRILLDOWN_TOOL_SLUG) ? [descriptor.drilldown.id] : []),
+    ...(definition.export &&
+    canUseAction(REPORT_EXPORT_TOOL_SLUG, 'reports.export')
+      ? ['export']
+      : []),
+  ];
+  return {
+    surfaceKind: 'report',
+    queryModes,
+    filterScopes: ['where', 'having'],
+    freshnessSource: 'reportLifecycle',
+    freshnessAvailableWithAuthenticatedDatabase: true,
+    allowedActions,
+    ...(definition.refresh &&
+    canUseAction(
+      REPORT_REFRESH_TOOL_SLUG,
+      descriptor.refresh.action.requiredPermission,
+    )
+      ? {
+          refreshPhases: descriptor.refresh.action.phases,
+          refreshRequiredPermission:
+            descriptor.refresh.action.requiredPermission,
+          refreshAuditRequired: descriptor.refresh.action.auditRequired,
+        }
+      : {}),
+    ...(canUse(REPORT_DRILLDOWN_TOOL_SLUG)
+      ? { drilldownSourceClass: descriptor.drilldown.sourceClassName }
+      : {}),
+    ...(definition.export &&
+    canUseAction(REPORT_EXPORT_TOOL_SLUG, 'reports.export')
+      ? { exportPhases: ['preview', 'apply'], exportSnapshotBound: true }
+      : {}),
+  };
+}
+
+async function configuredReports(
+  options: ReportDataSurfaceToolsOptions,
+  run: PrincipalRun,
+): Promise<readonly ReportDataSurfaceDefinition[]> {
+  return typeof options.reports === 'function'
+    ? options.reports(run)
+    : options.reports;
+}
+
+async function reportEntry(
+  options: ReportDataSurfaceToolsOptions,
+  run: PrincipalRun,
+  reportId: unknown,
+): Promise<{
+  definition: ReportDataSurfaceDefinition;
+  descriptor: ReportAdapterDescriptor;
+}> {
+  const requested = requiredString(reportId, 'reportId');
+  for (const definition of await configuredReports(options, run)) {
+    const descriptor = await buildReportAdapterDescriptor(
+      definition.report,
+      definition.adapter,
+    );
+    if (descriptor.resourceId !== requested) continue;
+    try {
+      await run.assertOperation(definition.collection, 'read');
+      return { definition, descriptor };
+    } catch {
+      break;
+    }
+  }
+  // Do not reveal whether a report exists, has different field policy, or is
+  // merely not readable under this principal.
+  throw new DataSurfaceDeniedError();
+}
+
+async function readOptions(
+  definition: ReportDataSurfaceDefinition,
+  context: DataSurfaceExecutionContext,
+): Promise<ReportReadOptions> {
+  return (await definition.query?.(context)) ?? {};
+}
+
+async function audit(
+  options: ReportDataSurfaceToolsOptions,
+  action: ReportDataSurfaceAuditEntry['action'],
+  reportId: string,
+  run: PrincipalRun,
+): Promise<void> {
+  await options.audit?.({
+    action,
+    reportId,
+    userId: principalFromRun(run).userId,
+    tenantId: run.context.tenantId,
+  });
+}
+
+function aiTool(
+  slug: string,
+  name: string,
+  description: string,
+  parameters: Record<string, unknown>,
+  execute: (context: PrincipalToolContext) => Promise<unknown>,
+): PrincipalTool {
+  return {
+    slug,
+    aiTool: {
+      type: 'function',
+      function: { name, description, parameters },
+    } satisfies AITool,
+    execute,
+  };
+}
+
+/**
+ * Convert a report adapter into the safe generic catalog consumed by
+ * data.discover/data.inspect/data.query. Generic agent queries are always
+ * silent; browser changes require the explicit report query tool below.
+ */
+export async function createReportDataSurfaceDefinition(
+  definition: ReportDataSurfaceDefinition,
+  run?: PrincipalRun,
+): Promise<DataSurfaceDefinition> {
+  const descriptor = await buildReportAdapterDescriptor(
+    definition.report,
+    definition.adapter,
+  );
+  return {
+    id: descriptor.resourceId,
+    collection: definition.collection,
+    className: descriptor.reportClassName,
+    label: definition.label ?? descriptor.reportClassName,
+    ...(definition.description ? { description: definition.description } : {}),
+    metadata: reportCatalogMetadata(definition, descriptor, run),
+    schema: querySchema(descriptor),
+    execute: async (_surface, request, context) => {
+      const db = reportDatabase(context.run, context.db);
+      const result = await queryReportMaterializedRows(
+        definition.report,
+        request,
+        {
+          ...(await readOptions(definition, context)),
+          adapter: definition.adapter,
+          ...(db ? { db, lifecycle: lifecycleOptions(db) } : {}),
+          execution: 'silent',
+        },
+      );
+      const {
+        execution: _execution,
+        reportLifecycle: _lifecycle,
+        ...data
+      } = result;
+      return data;
+    },
+  };
+}
+
+async function dataSurfaceCatalog(
+  options: ReportDataSurfaceToolsOptions,
+  run: PrincipalRun,
+): Promise<readonly DataSurfaceDefinition[]> {
+  return Promise.all(
+    (await configuredReports(options, run)).map((definition) =>
+      createReportDataSurfaceDefinition(definition, run),
+    ),
+  );
+}
+
+function commandResultIsBound(
+  ack: ReportDataSurfaceVisibleAck,
+  command: ReportDataSurfaceVisibleCommand,
+): boolean {
+  return (
+    ack.commandId === command.commandId &&
+    ack.identity.surfaceId === command.identity.surfaceId &&
+    ack.identity.kind === command.identity.kind &&
+    ack.revision === command.expectedRevision
+  );
+}
+
+function lifecycleOptions(
+  db: NonNullable<SmrtClassOptions['db']>,
+): Omit<ReportLifecycleOptions, 'db'> {
+  // Lifecycle has no caller-controlled authority fields. This small helper
+  // makes the export tool request the report's tenant-safe freshness snapshot.
+  void db;
+  return {};
+}
+
+/**
+ * Build generic report discovery/query tools plus report-only operational
+ * tools. Every report is looked up from a server-owned catalog per live run.
+ */
+export function createReportDataSurfaceTools(
+  options: ReportDataSurfaceToolsOptions,
+): PrincipalTool[] {
+  const generic = createDataSurfaceTools({
+    ...options.dataSurface,
+    surfaces: (run) => dataSurfaceCatalog(options, run),
+  });
+
+  const query = aiTool(
+    REPORT_QUERY_TOOL_SLUG,
+    REPORT_QUERY_FUNCTION_NAME,
+    'Run a bounded report query silently, in the background, or with an acknowledged browser update.',
+    {
+      type: 'object',
+      required: ['reportId', 'request'],
+      properties: {
+        reportId: { type: 'string' },
+        request: { type: 'object' },
+        execution: { enum: ['silent', 'background', 'visible'] },
+        expectedRevision: { type: 'integer', minimum: 0 },
+      },
+      additionalProperties: false,
+    },
+    async ({ run, args, db }) => {
+      run.assertToolAllowed(REPORT_QUERY_TOOL_SLUG);
+      const { definition, descriptor } = await reportEntry(
+        options,
+        run,
+        args.reportId,
+      );
+      let execution: 'silent' | 'background' | 'visible' = 'silent';
+      if (args.execution !== undefined) {
+        if (
+          args.execution !== 'silent' &&
+          args.execution !== 'background' &&
+          args.execution !== 'visible'
+        ) {
+          throw new ReportDataSurfaceConfigurationError(
+            'Report query execution is invalid',
+          );
+        }
+        execution = args.execution;
+      }
+      const context: DataSurfaceExecutionContext = {
+        run,
+        principal: principalFromRun(run),
+        db,
+        signal: new AbortController().signal,
+      };
+      const reportDb = reportDatabase(run, db);
+      const base = {
+        ...(await readOptions(definition, context)),
+        ...(reportDb
+          ? { db: reportDb, lifecycle: lifecycleOptions(reportDb) }
+          : {}),
+      };
+      if (execution === 'background') {
+        if (!definition.enqueueBackgroundQuery) {
+          throw new ReportDataSurfaceConfigurationError(
+            'This report does not expose a background query host',
+          );
+        }
+        const result = await queryReportMaterializedRows(
+          definition.report,
+          args.request,
+          {
+            ...base,
+            adapter: definition.adapter,
+            execution: 'background',
+            enqueueBackgroundQuery: (task) =>
+              definition.enqueueBackgroundQuery?.(task, { run }) ??
+              Promise.reject(
+                new ReportDataSurfaceConfigurationError(
+                  'This report does not expose a background query host',
+                ),
+              ),
+          },
+        );
+        await audit(options, 'query', descriptor.resourceId, run);
+        return result;
+      }
+
+      const result =
+        execution === 'silent'
+          ? await queryReportMaterializedRows(definition.report, args.request, {
+              ...base,
+              adapter: definition.adapter,
+              execution: 'silent',
+            })
+          : await queryReportMaterializedRows(definition.report, args.request, {
+              ...base,
+              adapter: definition.adapter,
+              execution: 'visible',
+            });
+      if (execution === 'silent') {
+        await audit(options, 'query', descriptor.resourceId, run);
+        return result;
+      }
+
+      if (!definition.visible) {
+        throw new ReportDataSurfaceConfigurationError(
+          'This report does not expose a browser-visible query host',
+        );
+      }
+      const expectedRevision = args.expectedRevision;
+      if (
+        typeof expectedRevision !== 'number' ||
+        !Number.isSafeInteger(expectedRevision) ||
+        expectedRevision < 0
+      ) {
+        throw new ReportDataSurfaceConfigurationError(
+          'Visible report queries require a non-negative expectedRevision',
+        );
+      }
+      const command: ReportDataSurfaceVisibleCommand = {
+        version: 1,
+        commandId: randomUUID(),
+        identity: { surfaceId: descriptor.resourceId, kind: 'report' },
+        expectedRevision,
+        controlId: 'query',
+        payload: { request: args.request as DataQueryRequest },
+      };
+      const acknowledged = await definition.visible.send(command, { run });
+      if (!commandResultIsBound(acknowledged, command) || !acknowledged.ok) {
+        throw new ReportDataSurfaceVisibleError(acknowledged.reason);
+      }
+      await audit(options, 'query', descriptor.resourceId, run);
+      return { ...result, browser: acknowledged };
+    },
+  );
+
+  const refresh = aiTool(
+    REPORT_REFRESH_TOOL_SLUG,
+    REPORT_REFRESH_FUNCTION_NAME,
+    'Preview or apply an authorized, audited report refresh.',
+    {
+      type: 'object',
+      required: ['reportId', 'phase'],
+      properties: {
+        reportId: { type: 'string' },
+        phase: { enum: ['preview', 'apply'] },
+        mode: { enum: ['rebuild', 'incremental'] },
+      },
+      additionalProperties: false,
+    },
+    async ({ run, args, db }) => {
+      run.assertToolAllowed(REPORT_REFRESH_TOOL_SLUG);
+      const { definition, descriptor } = await reportEntry(
+        options,
+        run,
+        args.reportId,
+      );
+      if (!definition.refresh) {
+        throw new ReportDataSurfaceConfigurationError(
+          'This report does not expose refresh',
+        );
+      }
+      if (args.phase !== 'preview' && args.phase !== 'apply') {
+        throw new ReportDataSurfaceConfigurationError(
+          'Report refresh phase is invalid',
+        );
+      }
+      const mode =
+        args.mode === undefined
+          ? undefined
+          : args.mode === 'rebuild' || args.mode === 'incremental'
+            ? args.mode
+            : (() => {
+                throw new ReportDataSurfaceConfigurationError(
+                  'Report refresh mode is invalid',
+                );
+              })();
+      const host = await definition.refresh.actionHost({ run });
+      const lifecycleDb = requireDatabase(run, db);
+      const result: ReportRefreshPreview | AppliedReportRefresh =
+        args.phase === 'preview'
+          ? await previewReportRefresh(definition.report, {
+              db: lifecycleDb,
+              host,
+              mode,
+              refreshAction: descriptor.refresh.action,
+            })
+          : await applyReportRefresh(definition.report, {
+              db: lifecycleDb,
+              host,
+              mode,
+              ...definition.refresh.options,
+              refreshAction: descriptor.refresh.action,
+            });
+      await audit(options, 'refresh', descriptor.resourceId, run);
+      return result;
+    },
+  );
+
+  const drilldown = aiTool(
+    REPORT_DRILLDOWN_TOOL_SLUG,
+    REPORT_DRILLDOWN_FUNCTION_NAME,
+    'Create a principal-bound source drilldown from one readable materialized report row.',
+    {
+      type: 'object',
+      required: ['reportId', 'rowId'],
+      properties: { reportId: { type: 'string' }, rowId: { type: 'string' } },
+      additionalProperties: false,
+    },
+    async ({ run, args, db }) => {
+      run.assertToolAllowed(REPORT_DRILLDOWN_TOOL_SLUG);
+      const { definition, descriptor } = await reportEntry(
+        options,
+        run,
+        args.reportId,
+      );
+      const rowId = requiredString(args.rowId, 'rowId');
+      const reportDb = reportDatabase(run, db);
+      const context: DataSurfaceExecutionContext = {
+        run,
+        principal: principalFromRun(run),
+        db: reportDb,
+        signal: new AbortController().signal,
+      };
+      const result = await queryReportMaterializedRows(
+        definition.report,
+        {
+          version: 1,
+          requestId: randomUUID(),
+          mode: 'rows',
+          projection: descriptor.drilldown.fields.map((field) => field.id),
+          filter: {
+            kind: 'condition',
+            field: 'id',
+            operator: 'eq',
+            value: rowId,
+          },
+          page: { kind: 'offset', offset: 0, limit: 1 },
+        },
+        {
+          ...(await readOptions(definition, context)),
+          adapter: definition.adapter,
+          ...(reportDb ? { db: reportDb } : {}),
+          execution: 'silent',
+        },
+      );
+      if (result.rows.length !== 1) throw new DataSurfaceDeniedError();
+      const handoff = await buildReportDrilldownQuery(
+        definition.report,
+        result.rows[0],
+        definition.adapter,
+      );
+      await audit(options, 'drilldown', descriptor.resourceId, run);
+      return handoff;
+    },
+  );
+
+  const exportTool = aiTool(
+    REPORT_EXPORT_TOOL_SLUG,
+    REPORT_EXPORT_FUNCTION_NAME,
+    'Preview or apply a principal-bound, snapshot-verified report export.',
+    {
+      type: 'object',
+      required: ['reportId', 'phase', 'query', 'format'],
+      properties: {
+        reportId: { type: 'string' },
+        phase: { enum: ['preview', 'apply'] },
+        query: { type: 'object' },
+        format: { enum: ['csv', 'json'] },
+        limits: { type: 'object' },
+        confirmed: { type: 'boolean' },
+      },
+      additionalProperties: false,
+    },
+    async ({ run, args, db }) => {
+      run.assertToolAllowed(REPORT_EXPORT_TOOL_SLUG);
+      const { definition, descriptor } = await reportEntry(
+        options,
+        run,
+        args.reportId,
+      );
+      if (!definition.export) {
+        throw new ReportDataSurfaceConfigurationError(
+          'This report does not expose export',
+        );
+      }
+      if (args.phase !== 'preview' && args.phase !== 'apply') {
+        throw new ReportDataSurfaceConfigurationError(
+          'Report export phase is invalid',
+        );
+      }
+      const exportDb = requireDatabase(run, db);
+      const context: DataSurfaceExecutionContext = {
+        run,
+        principal: principalFromRun(run),
+        db: exportDb,
+        signal: new AbortController().signal,
+      };
+      const result = await queryReportMaterializedRows(
+        definition.report,
+        args.query,
+        {
+          ...(await readOptions(definition, context)),
+          adapter: definition.adapter,
+          db: exportDb,
+          lifecycle: lifecycleOptions(exportDb),
+          execution: 'silent',
+        },
+      );
+      const binding = await definition.export.captureSnapshot({
+        run,
+        descriptor,
+        result,
+      });
+      const snapshot = createReportExportSnapshot(
+        descriptor,
+        args.query,
+        result,
+        binding,
+      );
+      const request = createReportExportRequest(descriptor, snapshot, {
+        format: args.format,
+        ...(args.limits === undefined ? {} : { limits: args.limits }),
+      });
+      const host = await definition.export.actionHost({ run });
+      const exported: ReportExportPreview | AppliedReportExport =
+        args.phase === 'preview'
+          ? await previewReportExport(descriptor, request, host)
+          : await applyReportExport(descriptor, request, host, {
+              confirmed: args.confirmed === true,
+            });
+      await audit(options, 'export', descriptor.resourceId, run);
+      return exported;
+    },
+  );
+
+  return [...generic, query, refresh, drilldown, exportTool];
+}

--- a/packages/agents/src/report-data-surface.ts
+++ b/packages/agents/src/report-data-surface.ts
@@ -257,12 +257,14 @@ function reportCatalogMetadata(
   definition: ReportDataSurfaceDefinition,
   descriptor: ReportAdapterDescriptor,
   run?: PrincipalRun,
+  auditAvailable = false,
 ): NonNullable<DataSurfaceDefinition['metadata']> {
   const canUse = (tool: string) => run?.isToolAllowed(tool) ?? true;
   const canUseAction = (tool: string, requiredPermission: string) =>
     canUse(tool) && (run?.permissions.includes(requiredPermission) ?? true);
   const canQuery =
     canUse(DATA_QUERY_TOOL_SLUG) || canUse(REPORT_QUERY_TOOL_SLUG);
+  const canDrilldown = auditAvailable && canUse(REPORT_DRILLDOWN_TOOL_SLUG);
   const queryModes = descriptor.queryExecution.modes.filter(
     (mode) =>
       (mode === 'silent' && canQuery) ||
@@ -282,7 +284,7 @@ function reportCatalogMetadata(
     )
       ? [descriptor.refresh.action.id]
       : []),
-    ...(canUse(REPORT_DRILLDOWN_TOOL_SLUG) ? [descriptor.drilldown.id] : []),
+    ...(canDrilldown ? [descriptor.drilldown.id] : []),
     ...(definition.export &&
     canUseAction(REPORT_EXPORT_TOOL_SLUG, 'reports.export')
       ? ['export']
@@ -307,7 +309,7 @@ function reportCatalogMetadata(
           refreshAuditRequired: descriptor.refresh.action.auditRequired,
         }
       : {}),
-    ...(canUse(REPORT_DRILLDOWN_TOOL_SLUG)
+    ...(canDrilldown
       ? { drilldownSourceClass: descriptor.drilldown.sourceClassName }
       : {}),
     ...(definition.export &&
@@ -399,6 +401,7 @@ function aiTool(
 export async function createReportDataSurfaceDefinition(
   definition: ReportDataSurfaceDefinition,
   run?: PrincipalRun,
+  auditAvailable = false,
 ): Promise<DataSurfaceDefinition> {
   const descriptor = await buildReportAdapterDescriptor(
     definition.report,
@@ -410,7 +413,12 @@ export async function createReportDataSurfaceDefinition(
     className: descriptor.reportClassName,
     label: definition.label ?? descriptor.reportClassName,
     ...(definition.description ? { description: definition.description } : {}),
-    metadata: reportCatalogMetadata(definition, descriptor, run),
+    metadata: reportCatalogMetadata(
+      definition,
+      descriptor,
+      run,
+      auditAvailable,
+    ),
     schema: querySchema(descriptor),
     execute: async (_surface, request, context) => {
       const db = reportDatabase(context.run, context.db);
@@ -440,7 +448,11 @@ async function dataSurfaceCatalog(
 ): Promise<readonly DataSurfaceDefinition[]> {
   return Promise.all(
     (await configuredReports(options, run)).map((definition) =>
-      createReportDataSurfaceDefinition(definition, run),
+      createReportDataSurfaceDefinition(
+        definition,
+        run,
+        typeof options.audit === 'function',
+      ),
     ),
   );
 }

--- a/packages/reports/AGENTS.md
+++ b/packages/reports/AGENTS.md
@@ -36,9 +36,12 @@ Materialized aggregate report models for SMRT.
   do not become public columns when no principal is available.
 - `tenantScoped`/`tenantField` reflect actual registered tenant metadata. A
   `tenantScope` option only contributes to the stable resource id; it is not
-  authorization. The default query path resolves the registered collection via
-  `ObjectRegistry`, so normal collection tenancy interceptors apply. An injected
-  collection is application-owned and must preserve the same boundary.
+  authorization. Pass the same `adapter` options to
+  `queryReportMaterializedRows()` that were used to build the selected
+  descriptor, so results and background tasks retain that stable resource id.
+  The default query path resolves the registered collection via `ObjectRegistry`,
+  so normal collection tenancy interceptors apply. An injected collection is
+  application-owned and must preserve the same boundary.
 - `refresh` is a declaration, not execution. It describes configured mode,
   triggers, positive-TTL stale-read behavior, and a permissioned/audited action
   with preview/apply phases. The adapter remains read-only, while

--- a/packages/reports/README.md
+++ b/packages/reports/README.md
@@ -145,7 +145,11 @@ const result = await queryReportMaterializedRows(
     page: { kind: 'offset', offset: 0, limit: 25 },
     sort: [{ field: 'revenue', direction: 'desc' }],
   },
-  { collection: reports },
+  {
+    collection: reports,
+    // Preserve the resource identity of the descriptor selected above.
+    adapter: { tenantScope: 'current' },
+  },
 );
 const rowKey = reportMaterializedRowKey(result.rows[0]);
 const drilldown = await buildReportDrilldownQuery(MonthlyRevenue, result.rows[0]);
@@ -192,6 +196,9 @@ and `background` delegates a normalized, authority-free task to the application'
 materialized rows. The host retains the authenticated principal, tenant, report
 definition, field policy, database, and eventual job execution; none can be
 supplied in a query request or background task.
+When a consumer selects a descriptor with `ReportAdapterOptions`, pass those
+same options through the query's `adapter` option so returned and background
+task resource ids stay aligned with the selected descriptor.
 `buildReportDrilldownQuery()` carries only the row's declared groups/buckets
 and a fixed inheritance contract for the current principal, tenant, report
 definition, and field policy; an authenticated source adapter must enforce that

--- a/packages/reports/src/adapter.ts
+++ b/packages/reports/src/adapter.ts
@@ -336,6 +336,11 @@ interface ReportQueryCommonOptions {
   };
   db?: import('@happyvertical/sql').DatabaseInterface;
   /**
+   * Consumer-owned descriptor preferences. They contribute to the stable
+   * resource identity and must match the catalog used to select this report.
+   */
+  adapter?: ReportAdapterOptions;
+  /**
    * Opt in to a tenant-safe lifecycle snapshot alongside this materialized
    * read. It never makes a generic read mutate.
    */
@@ -1368,7 +1373,10 @@ export async function queryReportMaterializedRows(
   input: unknown,
   options: ReportQueryOptions | ReportBackgroundQueryOptions = {},
 ): Promise<ReportDataQueryResult | ReportBackgroundQueryResult> {
-  const descriptor = await buildReportAdapterDescriptor(reportCtor);
+  const descriptor = await buildReportAdapterDescriptor(
+    reportCtor,
+    options.adapter,
+  );
   const request = normalizeDataQueryRequest(input, descriptor.schema);
   // Validate the semantic split even though materialized-row reads execute the
   // complete predicate against one persisted table. It prevents an adapter

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
       '@happyvertical/smrt-core':
         specifier: workspace:*
         version: link:../core
+      '@happyvertical/smrt-reports':
+        specifier: workspace:*
+        version: link:../reports
       '@happyvertical/smrt-secrets':
         specifier: workspace:*
         version: link:../secrets
@@ -1999,12 +2002,12 @@ importers:
       '@happyvertical/smrt-jobs':
         specifier: workspace:*
         version: link:../jobs
-      '@happyvertical/smrt-types':
-        specifier: workspace:*
-        version: link:../types
       '@happyvertical/smrt-tenancy':
         specifier: workspace:*
         version: link:../tenancy
+      '@happyvertical/smrt-types':
+        specifier: workspace:*
+        version: link:../types
       '@happyvertical/sql':
         specifier: ^0.88.0
         version: 0.88.0(@russellthehippo/honker-node@0.3.3)(@sqliteai/sqlite-vector@1.0.0)


### PR DESCRIPTION
## Summary

- publishes principal-bound report discovery, query, refresh, drilldown, and export tools
- preserves report field policy, tenant isolation, post-command visible acknowledgements, and background authority boundaries
- fails closed when a drilldown audit sink is unavailable and only advertises drilldown when that sink exists

## Validation

- `pnpm --filter @happyvertical/smrt-agents test -- report-data-surface.test.ts`
- `pnpm --filter @happyvertical/smrt-agents typecheck`
- `pnpm --filter @happyvertical/smrt-reports typecheck`
- `pnpm --filter @happyvertical/smrt-agents build`
- `pnpm knowledge:check --changed --strict --format markdown`
- `pnpm --dir packages/smrt-workbench/host build`
- `pnpm check:mcp-protocol-hygiene`

Closes #2462

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-2462-report-tools-reviewfix-20260825",
  "issue": 2462,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "pnpm --filter @happyvertical/smrt-agents test -- report-data-surface.test.ts",
    "pnpm --filter @happyvertical/smrt-agents typecheck",
    "pnpm --filter @happyvertical/smrt-reports typecheck",
    "pnpm --filter @happyvertical/smrt-agents build",
    "pnpm knowledge:check --changed --strict --format markdown",
    "pnpm --dir packages/smrt-workbench/host build",
    "pnpm check:mcp-protocol-hygiene"
  ]
}
```