### PR TITLE
feat(core): add bounded STI discriminator read scopes

### DIFF
--- a/packages/core/agents/collection-reads.md
+++ b/packages/core/agents/collection-reads.md
@@ -34,10 +34,13 @@ await impressionEvents.list({
 `stiScope.types` accepts 1–50 unique, qualified, registered types, all sharing
 the child collection's STI root. Empty, simple-name, unknown, duplicate,
 unrelated, and non-child scopes fail at the collection boundary. The option is
-supported by `list()`, `get()`, `count()`, `counts()`, `facets()`, and
+supported by `list()`, `count()`, `counts()`, `facets()`, and
 `listWithLatestRelated()`. These methods retain their normal field validation,
 projection or polymorphic hydration, pagination and cache-key construction;
 normal read and tenant interceptors still run and are ANDed with the allowlist.
+Point reads through `get()` remain child-only; use a bounded
+`list({ where, limit: 1, stiScope })` migration read when sibling hydration is
+required.
 
 For one child per parent, use
 [`latest-related.md`](latest-related.md). It uses a portable ranked CTE,

--- a/packages/core/agents/collection-reads.md
+++ b/packages/core/agents/collection-reads.md
@@ -12,6 +12,33 @@ returns plain rows without hydrating objects. It composes with `where`,
 `orderBy`, `limit`, and `offset`, runs normal `beforeList`/tenant interceptors,
 and is limited to column-backed fields; it cannot combine with `include`.
 
+## Bounded STI discriminator scopes
+
+An STI child collection remains scoped to its own qualified `_meta_type` by
+default. A migration that must read registered sibling types may opt into an
+explicit allowlist:
+
+```typescript
+await impressionEvents.list({
+  stiScope: {
+    types: [
+      '@anytown/advertising:AdImpression',
+      '@anytown/advertising:LegacyAdImpression',
+    ],
+  },
+  orderBy: 'created_at ASC',
+  limit: 100,
+});
+```
+
+`stiScope.types` accepts 1–50 unique, qualified, registered types, all sharing
+the child collection's STI root. Empty, simple-name, unknown, duplicate,
+unrelated, and non-child scopes fail at the collection boundary. The option is
+supported by `list()`, `get()`, `count()`, `counts()`, `facets()`, and
+`listWithLatestRelated()`. These methods retain their normal field validation,
+projection or polymorphic hydration, pagination and cache-key construction;
+normal read and tenant interceptors still run and are ANDed with the allowlist.
+
 For one child per parent, use
 [`latest-related.md`](latest-related.md). It uses a portable ranked CTE,
 declared primary keys, adapter-specific offset-only syntax, explicit aliases,

--- a/packages/core/src/__tests__/issue-2513-sti-read-scope-postgres.optional.test.ts
+++ b/packages/core/src/__tests__/issue-2513-sti-read-scope-postgres.optional.test.ts
@@ -1,0 +1,82 @@
+/** PostgreSQL adapter coverage for the bounded STI discriminator scope. */
+
+import { randomUUID } from 'node:crypto';
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { getDatabase } from '@happyvertical/sql';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { SmrtCollection } from '../collection.js';
+import { SmrtObject, smrt } from '../index.js';
+import { ObjectRegistry } from '../registry.js';
+
+const pgUrl = process.env.SMRT_TEST_POSTGRES_URL;
+const TABLE = 'issue_2513_postgres_sti_scope';
+const CURRENT_TYPE = '@happyvertical/smrt-core:Issue2513PgCurrent';
+const HISTORICAL_TYPE = '@happyvertical/smrt-core:Issue2513PgHistorical';
+
+@smrt({
+  tableName: 'issue_2513_postgres_sti_scope',
+  tableStrategy: 'sti',
+})
+class Issue2513PgEvent extends SmrtObject {
+  title: string = '';
+}
+
+@smrt()
+class Issue2513PgCurrent extends Issue2513PgEvent {}
+
+@smrt()
+class Issue2513PgHistorical extends Issue2513PgEvent {}
+
+class Issue2513PgCurrentCollection extends SmrtCollection<Issue2513PgCurrent> {
+  static readonly _itemClass = Issue2513PgCurrent;
+}
+
+class Issue2513PgHistoricalCollection extends SmrtCollection<Issue2513PgHistorical> {
+  static readonly _itemClass = Issue2513PgHistorical;
+}
+
+describe.skipIf(!pgUrl)('bounded STI read scope on PostgreSQL (#2513)', () => {
+  let db: DatabaseInterface;
+  let current: Issue2513PgCurrentCollection;
+
+  beforeAll(async () => {
+    db = (await getDatabase({
+      type: 'postgres',
+      url: pgUrl,
+      dbid: `smrt-test-2513-${randomUUID()}`,
+    } as Parameters<typeof getDatabase>[0])) as DatabaseInterface;
+    await db.query(`DROP TABLE IF EXISTS "${TABLE}"`);
+    const registration = ObjectRegistry.getClassByConstructor(Issue2513PgEvent);
+    const className =
+      registration?.qualifiedName ??
+      registration?.name ??
+      Issue2513PgEvent.name;
+    const ddl = ObjectRegistry.getSchemaDDL(className, 'postgres');
+    if (!ddl) throw new Error(`Missing schema DDL for ${className}`);
+    await db.query(ddl);
+
+    const historical = await Issue2513PgHistoricalCollection.create({ db });
+    current = await Issue2513PgCurrentCollection.create({ db });
+    await current.create({ title: 'current' });
+    await historical.create({ title: 'historical' });
+  }, 60_000);
+
+  afterAll(async () => {
+    try {
+      await db?.query(`DROP TABLE IF EXISTS "${TABLE}"`);
+    } finally {
+      await db?.close?.();
+    }
+  });
+
+  it('binds a qualified allowlist and hydrates both registered sibling types', async () => {
+    const rows = await current.list({
+      stiScope: { types: [CURRENT_TYPE, HISTORICAL_TYPE] },
+      orderBy: 'title ASC',
+      limit: 2,
+    });
+    expect(rows.map((row) => row.title)).toEqual(['current', 'historical']);
+    expect(rows[0]).toBeInstanceOf(Issue2513PgCurrent);
+    expect(rows[1]).toBeInstanceOf(Issue2513PgHistorical);
+  });
+});

--- a/packages/core/src/__tests__/issue-2513-sti-read-scope.test.ts
+++ b/packages/core/src/__tests__/issue-2513-sti-read-scope.test.ts
@@ -1,5 +1,5 @@
 import type { DatabaseInterface } from '@happyvertical/sql';
-import { afterEach, describe, expect, expectTypeOf, it } from 'vitest';
+import { afterEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 import {
   MAX_STI_READ_SCOPE_TYPES,
   SmrtCollection,
@@ -8,7 +8,7 @@ import {
   type SmrtStiReadScope,
 } from '../collection.js';
 import { field, foreignKey, oneToMany } from '../decorators/index.js';
-import { SmrtObject, smrt } from '../index.js';
+import { ObjectRegistry, SmrtObject, smrt } from '../index.js';
 import { GlobalInterceptors } from '../interceptors.js';
 import { getTestDatabase } from '../testing/database.js';
 
@@ -142,6 +142,7 @@ describe.each([
   let db: DatabaseInterface | undefined;
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     GlobalInterceptors.unregister('issue-2513-tenant');
     await db?.close?.();
     db = undefined;
@@ -235,6 +236,22 @@ describe.each([
       return originalQuery(sql, ...params);
     }) as DatabaseInterface['query'];
 
+    // Simulate an external sibling disappearing from the local registry after
+    // allowlist validation but before row hydration. The hydration boundary
+    // must invoke manifest loading before it asks for concrete field metadata.
+    const originalGetClass = ObjectRegistry.getClass.bind(ObjectRegistry);
+    let historicalLookups = 0;
+    vi.spyOn(ObjectRegistry, 'getClass').mockImplementation((name) => {
+      if (name === HISTORICAL_TYPE && ++historicalLookups === 2) {
+        return undefined;
+      }
+      return originalGetClass(name);
+    });
+    const ensureManifestLoaded = vi.spyOn(
+      ObjectRegistry,
+      'ensureManifestLoaded',
+    );
+
     const scoped = await current.list({
       stiScope: allTypesScope,
       orderBy: 'title ASC',
@@ -253,6 +270,7 @@ describe.each([
     expect(scoped[1].attempts).toBe(7);
     expect(scoped[1].occurredAt).toEqual(new Date('2025-01-02T03:04:05.000Z'));
     expect(scoped[1].payload).toEqual({ source: 'legacy', version: 2 });
+    expect(ensureManifestLoaded).toHaveBeenCalledWith(HISTORICAL_TYPE);
     expect(scoped.map((event) => event.title)).toEqual([
       'Current A',
       'Historical A',
@@ -295,6 +313,7 @@ describe.each([
       },
     ]);
 
+    const getAllFields = vi.spyOn(ObjectRegistry, 'getAllFields');
     const latestRelatedPromise = current.listWithLatestRelated({
       stiScope: allTypesScope,
       latestRelated: {
@@ -319,6 +338,12 @@ describe.each([
       'current note',
       'historical note',
     ]);
+    expect(
+      getAllFields.mock.calls.filter(([type]) => type === CURRENT_TYPE),
+    ).toHaveLength(1);
+    expect(
+      getAllFields.mock.calls.filter(([type]) => type === HISTORICAL_TYPE),
+    ).toHaveLength(1);
     expect(await current.count()).toBe(1);
     expect(await current.count({ stiScope: allTypesScope })).toBe(2);
     await expect(

--- a/packages/core/src/__tests__/issue-2513-sti-read-scope.test.ts
+++ b/packages/core/src/__tests__/issue-2513-sti-read-scope.test.ts
@@ -1,0 +1,363 @@
+import type { DatabaseInterface } from '@happyvertical/sql';
+import { afterEach, describe, expect, expectTypeOf, it } from 'vitest';
+import {
+  MAX_STI_READ_SCOPE_TYPES,
+  SmrtCollection,
+  type SmrtLatestRelatedListOptions,
+  type SmrtListOptions,
+  type SmrtStiReadScope,
+} from '../collection.js';
+import { field, foreignKey, oneToMany } from '../decorators/index.js';
+import { SmrtObject, smrt } from '../index.js';
+import { GlobalInterceptors } from '../interceptors.js';
+import { getTestDatabase } from '../testing/database.js';
+
+const TENANT_A = '00000000-0000-4000-8000-000000002513';
+const TENANT_B = '00000000-0000-4000-8000-000000002514';
+const CURRENT_TYPE = '@happyvertical/smrt-core:ScopeCurrentEvent';
+const HISTORICAL_TYPE = '@happyvertical/smrt-core:ScopeHistoricalEvent';
+
+@smrt({
+  tableStrategy: 'sti',
+  idType: 'text',
+  tenantScoped: { mode: 'optional', autoPopulate: false },
+})
+class ScopeEvent extends SmrtObject {
+  title: string = '';
+  status: string = '';
+  tenantId: string | null = null;
+}
+
+@smrt()
+class ScopeCurrentEvent extends ScopeEvent {
+  accountKey: string = '';
+
+  @oneToMany('ScopeEventNote')
+  notes: ScopeEventNote[] = [];
+}
+
+@smrt()
+class ScopeHistoricalEvent extends ScopeEvent {
+  legacyKey: string = '';
+}
+
+@smrt({ tableStrategy: 'sti' })
+class OtherScopeRoot extends SmrtObject {
+  label: string = '';
+}
+
+@smrt()
+class OtherScopeChild extends OtherScopeRoot {}
+
+@smrt({ idType: 'text' })
+class ScopeEventNote extends SmrtObject {
+  @foreignKey(ScopeCurrentEvent, {
+    constraint: { engines: ['postgres', 'sqlite'] },
+  })
+  eventId: string = '';
+
+  @field()
+  sequence: number = 0;
+
+  @field()
+  note: string = '';
+}
+
+class ScopeEventCollection extends SmrtCollection<ScopeEvent> {
+  static readonly _itemClass = ScopeEvent;
+}
+
+class ScopeCurrentEventCollection extends SmrtCollection<ScopeCurrentEvent> {
+  static readonly _itemClass = ScopeCurrentEvent;
+}
+
+class ScopeHistoricalEventCollection extends SmrtCollection<ScopeHistoricalEvent> {
+  static readonly _itemClass = ScopeHistoricalEvent;
+}
+
+class ScopeEventNoteCollection extends SmrtCollection<ScopeEventNote> {
+  static readonly _itemClass = ScopeEventNote;
+}
+
+const allTypesScope: SmrtStiReadScope = {
+  types: [CURRENT_TYPE, HISTORICAL_TYPE],
+};
+
+function assertPublicReadTypes(current: ScopeCurrentEventCollection): void {
+  const publicListOptions: SmrtListOptions<ScopeCurrentEvent> = {};
+  const publicLatestOptions: SmrtLatestRelatedListOptions<ScopeCurrentEvent> = {
+    latestRelated: {
+      relation: 'notes',
+      orderBy: 'sequence DESC',
+    },
+  };
+  expectTypeOf(current.list()).resolves.toEqualTypeOf<ScopeCurrentEvent[]>();
+  expectTypeOf(
+    current.list({ stiScope: allTypesScope }),
+  ).resolves.toEqualTypeOf<SmrtObject[]>();
+  expectTypeOf(
+    current.get('current-a', { stiScope: allTypesScope }),
+  ).resolves.toEqualTypeOf<SmrtObject | null>();
+  expectTypeOf(current.list(publicListOptions)).resolves.toEqualTypeOf<
+    SmrtObject[]
+  >();
+  function listThroughPublicOptions(
+    options: SmrtListOptions<ScopeCurrentEvent>,
+  ) {
+    return current.list(options);
+  }
+  expectTypeOf(listThroughPublicOptions).returns.toEqualTypeOf<
+    Promise<SmrtObject[] | Record<string, unknown>[]>
+  >();
+  expectTypeOf(
+    current.listWithLatestRelated(publicLatestOptions),
+  ).resolves.toEqualTypeOf<
+    Array<{
+      parent: SmrtObject;
+      latestRelated: Record<string, unknown> | null;
+    }>
+  >();
+}
+void assertPublicReadTypes;
+
+describe.each([
+  { name: 'SQLite', type: 'sqlite' as const },
+  { name: 'DuckDB', type: 'duckdb' as const },
+])('bounded STI read scope on $name (#2513)', ({ type }) => {
+  let db: DatabaseInterface | undefined;
+
+  afterEach(async () => {
+    GlobalInterceptors.unregister('issue-2513-tenant');
+    await db?.close?.();
+    db = undefined;
+  });
+
+  async function setup() {
+    db = await getTestDatabase({
+      type,
+      url: ':memory:',
+      classes: [
+        'ScopeEvent',
+        'ScopeCurrentEvent',
+        'ScopeHistoricalEvent',
+        'ScopeEventNote',
+      ],
+    });
+    const current = await ScopeCurrentEventCollection.create({ db });
+    const historical = await ScopeHistoricalEventCollection.create({ db });
+    const base = await ScopeEventCollection.create({ db });
+    const notes = await ScopeEventNoteCollection.create({ db });
+
+    const currentA = await current.create({
+      title: 'Current A',
+      status: 'open',
+      accountKey: 'account-a',
+      tenantId: TENANT_A,
+    });
+    const historicalA = await historical.create({
+      title: 'Historical A',
+      status: 'open',
+      legacyKey: 'legacy-a',
+      tenantId: TENANT_A,
+    });
+    await current.create({
+      title: 'Current B',
+      status: 'closed',
+      accountKey: 'account-b',
+      tenantId: TENANT_B,
+    });
+    await notes.create({
+      eventId: currentA.id,
+      sequence: 1,
+      note: 'current note',
+    });
+    await notes.create({
+      eventId: historicalA.id,
+      sequence: 1,
+      note: 'historical note',
+    });
+
+    GlobalInterceptors.register({
+      name: 'issue-2513-tenant',
+      beforeList(className, options) {
+        if (className !== 'ScopeCurrentEvent') return options;
+        return {
+          ...options,
+          where: {
+            ...(options.where as Record<string, unknown>),
+            tenantId: TENANT_A,
+          },
+        };
+      },
+      beforeGet(className, filter) {
+        if (className !== 'ScopeCurrentEvent') return filter;
+        return {
+          ...(filter as Record<string, unknown>),
+          tenantId: TENANT_A,
+        };
+      },
+    });
+
+    return { base, current, currentA, historicalA };
+  }
+
+  it('keeps child-only defaults and reads an allowlisted sibling scope in one bounded query', async () => {
+    const { current } = await setup();
+    await expect(current.list({ orderBy: 'title ASC' })).resolves.toMatchObject(
+      [{ title: 'Current A' }],
+    );
+
+    const queries: string[] = [];
+    const activeDb = db;
+    if (!activeDb) throw new Error('Test database was not initialized.');
+    const originalQuery = activeDb.query.bind(activeDb);
+    activeDb.query = (async (sql: string, ...params: unknown[]) => {
+      queries.push(sql);
+      return originalQuery(sql, ...params);
+    }) as DatabaseInterface['query'];
+
+    const scoped = await current.list({
+      stiScope: allTypesScope,
+      orderBy: 'title ASC',
+      limit: 2,
+      offset: 0,
+      cache: { ttl: 60_000 },
+    });
+
+    expect(scoped).toHaveLength(2);
+    expect(scoped[0]).toBeInstanceOf(ScopeCurrentEvent);
+    expect(scoped[1]).toBeInstanceOf(ScopeHistoricalEvent);
+    expect(scoped.map((event) => event.title)).toEqual([
+      'Current A',
+      'Historical A',
+    ]);
+    expect(
+      queries.filter((sql) => sql.includes(`FROM ${current.tableName}`)),
+    ).toHaveLength(1);
+
+    await current.list({
+      stiScope: allTypesScope,
+      orderBy: 'title ASC',
+      limit: 2,
+      offset: 0,
+      cache: { ttl: 60_000 },
+    });
+    expect(
+      queries.filter((sql) => sql.includes(`FROM ${current.tableName}`)),
+    ).toHaveLength(1);
+  });
+
+  it('preserves child projection, point-read hydration, counts, facets, and tenancy', async () => {
+    const { current, historicalA } = await setup();
+
+    await expect(
+      current.list({
+        stiScope: allTypesScope,
+        select: ['title', 'accountKey', '_meta_type'] as const,
+        orderBy: 'title ASC',
+      }),
+    ).resolves.toEqual([
+      {
+        title: 'Current A',
+        accountKey: 'account-a',
+        _meta_type: CURRENT_TYPE,
+      },
+      {
+        title: 'Historical A',
+        accountKey: '',
+        _meta_type: HISTORICAL_TYPE,
+      },
+    ]);
+
+    const historical = await current.get(
+      { id: historicalA.id },
+      { stiScope: allTypesScope },
+    );
+    expect(historical).toBeInstanceOf(ScopeHistoricalEvent);
+    const latestRelatedPromise = current.listWithLatestRelated({
+      stiScope: allTypesScope,
+      latestRelated: {
+        relation: 'notes',
+        orderBy: 'sequence DESC',
+        select: ['note'],
+      },
+      orderBy: 'title ASC',
+      limit: 2,
+    });
+    expectTypeOf(latestRelatedPromise).resolves.toEqualTypeOf<
+      Array<{
+        parent: SmrtObject;
+        latestRelated: Record<string, unknown> | null;
+      }>
+    >();
+    const latestRelated = await latestRelatedPromise;
+    expect(latestRelated).toHaveLength(2);
+    expect(latestRelated[0]?.parent).toBeInstanceOf(ScopeCurrentEvent);
+    expect(latestRelated[1]?.parent).toBeInstanceOf(ScopeHistoricalEvent);
+    expect(latestRelated.map((row) => row.latestRelated?.note)).toEqual([
+      'current note',
+      'historical note',
+    ]);
+    expect(await current.count()).toBe(1);
+    expect(await current.count({ stiScope: allTypesScope })).toBe(2);
+    await expect(
+      current.counts({
+        stiScope: allTypesScope,
+        where: { status: 'open' },
+      }),
+    ).resolves.toEqual({ total: 2, filtered: 2 });
+    await expect(
+      current.facets({
+        stiScope: allTypesScope,
+        fields: ['status'],
+      }),
+    ).resolves.toEqual([
+      { field: 'status', values: [{ value: 'open', count: 2 }] },
+    ]);
+  });
+
+  it('rejects malformed, unknown, duplicate, oversized, base, and unrelated scopes', async () => {
+    const { base, current } = await setup();
+
+    await expect(current.list({ stiScope: { types: [] } })).rejects.toThrow(
+      /must not be empty/,
+    );
+    await expect(
+      current.list({ stiScope: { types: ['ScopeHistoricalEvent'] } }),
+    ).rejects.toThrow(/qualified SMRT type/);
+    await expect(
+      current.list({
+        stiScope: { types: ['@happyvertical/smrt-core:MissingScopeEvent'] },
+      }),
+    ).rejects.toThrow(/unknown type/);
+    await expect(
+      current.list({ stiScope: { types: [CURRENT_TYPE, CURRENT_TYPE] } }),
+    ).rejects.toThrow(/duplicate type/);
+    await expect(
+      current.list({
+        stiScope: {
+          types: Array.from(
+            { length: MAX_STI_READ_SCOPE_TYPES + 1 },
+            (_, index) => `@fixture/scope:Type${index}`,
+          ),
+        },
+      }),
+    ).rejects.toThrow(`at most ${MAX_STI_READ_SCOPE_TYPES} types`);
+    await expect(
+      current.list({
+        stiScope: {
+          types: ['@happyvertical/smrt-core:OtherScopeChild'],
+        },
+      }),
+    ).rejects.toThrow(/does not share STI root/);
+    await expect(base.list({ stiScope: allTypesScope })).rejects.toThrow(
+      /require an STI child collection/,
+    );
+    const malformedScope = JSON.parse(
+      `{"types":["${CURRENT_TYPE}"],"extra":true}`,
+    );
+    await expect(current.list({ stiScope: malformedScope })).rejects.toThrow(
+      /expected \{ types/,
+    );
+  });
+});

--- a/packages/core/src/__tests__/issue-2513-sti-read-scope.test.ts
+++ b/packages/core/src/__tests__/issue-2513-sti-read-scope.test.ts
@@ -39,6 +39,18 @@ class ScopeCurrentEvent extends ScopeEvent {
 @smrt()
 class ScopeHistoricalEvent extends ScopeEvent {
   legacyKey: string = '';
+
+  @field({ type: 'boolean' })
+  archived: boolean = false;
+
+  @field({ type: 'integer' })
+  attempts: number = 0;
+
+  @field({ type: 'datetime' })
+  occurredAt: Date = new Date(0);
+
+  @field({ type: 'json' })
+  payload: Record<string, unknown> = {};
 }
 
 @smrt({ tableStrategy: 'sti' })
@@ -161,6 +173,10 @@ describe.each([
       title: 'Historical A',
       status: 'open',
       legacyKey: 'legacy-a',
+      archived: true,
+      attempts: 7,
+      occurredAt: new Date('2025-01-02T03:04:05.000Z'),
+      payload: { source: 'legacy', version: 2 },
       tenantId: TENANT_A,
     });
     await current.create({
@@ -230,6 +246,13 @@ describe.each([
     expect(scoped).toHaveLength(2);
     expect(scoped[0]).toBeInstanceOf(ScopeCurrentEvent);
     expect(scoped[1]).toBeInstanceOf(ScopeHistoricalEvent);
+    if (!(scoped[1] instanceof ScopeHistoricalEvent)) {
+      throw new Error('Expected historical sibling hydration.');
+    }
+    expect(scoped[1].archived).toBe(true);
+    expect(scoped[1].attempts).toBe(7);
+    expect(scoped[1].occurredAt).toEqual(new Date('2025-01-02T03:04:05.000Z'));
+    expect(scoped[1].payload).toEqual({ source: 'legacy', version: 2 });
     expect(scoped.map((event) => event.title)).toEqual([
       'Current A',
       'Historical A',

--- a/packages/core/src/__tests__/issue-2513-sti-read-scope.test.ts
+++ b/packages/core/src/__tests__/issue-2513-sti-read-scope.test.ts
@@ -95,9 +95,6 @@ function assertPublicReadTypes(current: ScopeCurrentEventCollection): void {
   expectTypeOf(
     current.list({ stiScope: allTypesScope }),
   ).resolves.toEqualTypeOf<SmrtObject[]>();
-  expectTypeOf(
-    current.get('current-a', { stiScope: allTypesScope }),
-  ).resolves.toEqualTypeOf<SmrtObject | null>();
   expectTypeOf(current.list(publicListOptions)).resolves.toEqualTypeOf<
     SmrtObject[]
   >();
@@ -247,7 +244,7 @@ describe.each([
     ).toHaveLength(1);
   });
 
-  it('preserves child projection, point-read hydration, counts, facets, and tenancy', async () => {
+  it('preserves child projection, polymorphic hydration, counts, facets, and tenancy', async () => {
     const { current, historicalA } = await setup();
 
     await expect(
@@ -269,11 +266,6 @@ describe.each([
       },
     ]);
 
-    const historical = await current.get(
-      { id: historicalA.id },
-      { stiScope: allTypesScope },
-    );
-    expect(historical).toBeInstanceOf(ScopeHistoricalEvent);
     const latestRelatedPromise = current.listWithLatestRelated({
       stiScope: allTypesScope,
       latestRelated: {

--- a/packages/core/src/__tests__/issue-2513-sti-read-scope.test.ts
+++ b/packages/core/src/__tests__/issue-2513-sti-read-scope.test.ts
@@ -95,6 +95,12 @@ function assertPublicReadTypes(current: ScopeCurrentEventCollection): void {
   expectTypeOf(
     current.list({ stiScope: allTypesScope }),
   ).resolves.toEqualTypeOf<SmrtObject[]>();
+  expectTypeOf(
+    current.list({ select: ['title'] as const }),
+  ).resolves.toEqualTypeOf<Array<{ title: string }>>();
+  expectTypeOf(
+    current.list({ select: ['title'] as const, stiScope: allTypesScope }),
+  ).resolves.toEqualTypeOf<Record<string, unknown>[]>();
   expectTypeOf(current.list(publicListOptions)).resolves.toEqualTypeOf<
     SmrtObject[]
   >();

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -4222,9 +4222,19 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     row: Record<string, unknown>,
     fields: Record<string, CollectionFieldDefinition>,
     isSTI: boolean,
+    polymorphicFields = new Map<
+      string,
+      Record<string, CollectionFieldDefinition>
+    >(),
   ): Promise<ModelType> {
+    const hydrationFields = await this.resolveHydrationFields(
+      row,
+      fields,
+      isSTI,
+      polymorphicFields,
+    );
     const formattedData = this.withHydratedCoreFields(
-      formatDataJs(row, fields),
+      formatDataJs(row, hydrationFields),
     );
 
     const metaType = formattedData._meta_type;
@@ -4265,6 +4275,40 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
   }
 
   /**
+   * Resolve inherited field metadata for an STI row's concrete discriminator.
+   * The caller-provided collection fields remain the safe fallback for
+   * non-polymorphic, malformed, or not-yet-registered rows.
+   */
+  private async resolveHydrationFields(
+    row: Record<string, unknown>,
+    fallbackFields: Record<string, CollectionFieldDefinition>,
+    isSTI: boolean,
+    polymorphicFields: Map<string, Record<string, CollectionFieldDefinition>>,
+  ): Promise<Record<string, CollectionFieldDefinition>> {
+    if (!isSTI) return fallbackFields;
+
+    const rawMetaType = row._meta_type ?? row._metaType;
+    if (rawMetaType === null || rawMetaType === undefined) {
+      return fallbackFields;
+    }
+
+    const metaType = String(rawMetaType);
+    const cached = polymorphicFields.get(metaType);
+    if (cached) return cached;
+    if (!ObjectRegistry.getClass(metaType)) return fallbackFields;
+
+    const registeredFields = await ObjectRegistry.getAllFields(metaType);
+    if (registeredFields.size === 0) return fallbackFields;
+
+    const concreteFields: Record<string, CollectionFieldDefinition> = {};
+    for (const [fieldName, field] of registeredFields) {
+      concreteFields[fieldName] = { type: field.type };
+    }
+    polymorphicFields.set(metaType, concreteFields);
+    return concreteFields;
+  }
+
+  /**
    * Hydrate rows in result order.
    *
    * A model's initialize() hook may query through the collection database.
@@ -4279,8 +4323,14 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     isSTI: boolean,
   ): Promise<ModelType[]> {
     const instances: ModelType[] = [];
+    const polymorphicFields = new Map<
+      string,
+      Record<string, CollectionFieldDefinition>
+    >();
     for (const row of rows) {
-      instances.push(await this.hydrateResultRow(row, fields, isSTI));
+      instances.push(
+        await this.hydrateResultRow(row, fields, isSTI, polymorphicFields),
+      );
     }
     return instances;
   }

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -2757,9 +2757,17 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    * @returns Promise resolving to an array of model instances, or plain selected rows when `select` is present
    */
   public async list<const Select extends readonly SmrtSelectField<ModelType>[]>(
-    options: SmrtListOptions<ModelType> & {
+    options: Omit<SmrtListOptions<ModelType>, 'select' | 'stiScope'> & {
       select: Select;
       include?: never;
+      stiScope: SmrtStiReadScope;
+    },
+  ): Promise<Record<string, unknown>[]>;
+  public async list<const Select extends readonly SmrtSelectField<ModelType>[]>(
+    options: Omit<SmrtListOptions<ModelType>, 'select' | 'stiScope'> & {
+      select: Select;
+      include?: never;
+      stiScope?: undefined;
     },
   ): Promise<SmrtSelectedRow<ModelType, Select>[]>;
   public async list(

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -2032,12 +2032,21 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     // would violate the collection-wide serial hydration invariant.
     const instances: ModelType[] = [];
     const relatedAliasNames = new Set(relatedFieldAliases.values());
+    const polymorphicFields = new Map<
+      string,
+      Record<string, CollectionFieldDefinition>
+    >();
     for (const row of rows.rows as Record<string, unknown>[]) {
       const parentRow = Object.fromEntries(
         Object.entries(row).filter(([key]) => !relatedAliasNames.has(key)),
       );
       instances.push(
-        await this.hydrateResultRow(parentRow, parentFields, isSTI),
+        await this.hydrateResultRow(
+          parentRow,
+          parentFields,
+          isSTI,
+          polymorphicFields,
+        ),
       );
     }
 
@@ -4295,7 +4304,9 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     const metaType = String(rawMetaType);
     const cached = polymorphicFields.get(metaType);
     if (cached) return cached;
-    if (!ObjectRegistry.getClass(metaType)) return fallbackFields;
+    if (!ObjectRegistry.getClass(metaType)) {
+      await ObjectRegistry.ensureManifestLoaded(metaType);
+    }
 
     const registeredFields = await ObjectRegistry.getAllFields(metaType);
     if (registeredFields.size === 0) return fallbackFields;

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -2623,32 +2623,8 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    */
   public async get(
     filter: string | SmrtWhereClause<ModelType>,
-    options: {
-      cache?: CollectionCacheConfig | false;
-      stiScope: SmrtStiReadScope;
-    },
-  ): Promise<SmrtObject | null>;
-  public async get(
-    filter: string | SmrtWhereClause<ModelType>,
-    options?: {
-      cache?: CollectionCacheConfig | false;
-      stiScope?: undefined;
-    },
-  ): Promise<ModelType | null>;
-  public async get(
-    filter: string | SmrtWhereClause<ModelType>,
-    options?: {
-      cache?: CollectionCacheConfig | false;
-      stiScope?: SmrtStiReadScope;
-    },
-  ): Promise<SmrtObject | null>;
-  public async get(
-    filter: string | SmrtWhereClause<ModelType>,
-    options: {
-      cache?: CollectionCacheConfig | false;
-      stiScope?: SmrtStiReadScope;
-    } = {},
-  ): Promise<SmrtObject | null> {
+    options: { cache?: CollectionCacheConfig | false } = {},
+  ): Promise<ModelType | null> {
     await this.ensureStorageReady();
     const itemClassName = this.getResolvedItemClassName();
     const itemQualifiedName = this.getResolvedItemQualifiedName();
@@ -2682,11 +2658,15 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     const tableStrategy = ObjectRegistry.getTableStrategy(itemQualifiedName);
     const isSTI = tableStrategy === 'sti';
 
-    const scopedWhere = this.applyStiReadScope(where, options.stiScope);
-    if (Array.isArray(scopedWhere)) {
-      throw new Error('Invalid STI point-read scope.');
+    if (isSTI) {
+      const stiBase = ObjectRegistry.getSTIBase(itemQualifiedName);
+      if (stiBase && stiBase !== itemQualifiedName) {
+        where = {
+          _meta_type: itemQualifiedName,
+          ...where,
+        };
+      }
     }
-    where = scopedWhere ?? where;
 
     // convertWhereKeys is now sync (issue #663) - no await needed
     const convertedWhere = this.convertWhereKeys(where);
@@ -2788,20 +2768,29 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       stiScope: SmrtStiReadScope;
     },
   ): Promise<SmrtObject[]>;
+  public async list(options?: undefined): Promise<ModelType[]>;
   public async list(
-    options?: Omit<SmrtListOptions<ModelType>, 'select' | 'stiScope'> & {
+    options: Omit<SmrtListOptions<ModelType>, 'select' | 'stiScope'> & {
       select?: undefined;
       stiScope?: undefined;
     },
   ): Promise<ModelType[]>;
   public async list(
-    options?: Omit<SmrtListOptions<ModelType>, 'select'> & {
-      select?: undefined;
-    },
+    options:
+      | (Omit<SmrtListOptions<ModelType>, 'select'> & {
+          select?: undefined;
+        })
+      | undefined,
   ): Promise<SmrtObject[]>;
   public async list(
-    options?: SmrtListOptions<ModelType>,
+    options: SmrtListOptions<ModelType> | undefined,
   ): Promise<SmrtObject[] | Record<string, unknown>[]>;
+  public async list(
+    options: Omit<SmrtListOptions<ModelType>, 'select' | 'stiScope'> & {
+      select?: undefined;
+      stiScope?: undefined;
+    },
+  ): Promise<ModelType[]>;
   public async list(
     options: SmrtListOptions<ModelType> = {},
   ): Promise<SmrtObject[] | Record<string, unknown>[]> {

--- a/packages/core/src/collection.ts
+++ b/packages/core/src/collection.ts
@@ -69,6 +69,9 @@ export const DEFAULT_FACET_LIMIT = DEFAULT_LIST_LIMIT;
 /** Hard ceiling for distinct values returned for one facet field. */
 export const MAX_FACET_LIMIT = MAX_LIST_LIMIT;
 
+/** Maximum number of qualified STI discriminators accepted by one read. */
+export const MAX_STI_READ_SCOPE_TYPES = 50;
+
 /**
  * Validate an optional collection-level list bound (#2367).
  *
@@ -366,12 +369,23 @@ export interface SmrtFacetOptions<T extends SmrtObject> {
   fields: readonly (SmrtSelectField<T> | SmrtFacetRequest<T>)[];
   /** The same SMRT WHERE syntax accepted by {@link SmrtCollection.list}. */
   where?: SmrtListWhereClause<T>;
+  /** Explicit sibling discriminator scope for an STI child collection. */
+  stiScope?: SmrtStiReadScope;
 }
 
 /** Exact unfiltered and filtered row counts for a list scope. */
 export interface SmrtCollectionCounts {
   total: number;
   filtered: number;
+}
+
+/**
+ * Explicit, bounded discriminator scope for reads through an STI child
+ * collection. Every entry must be a registered qualified type in the same STI
+ * hierarchy as the collection item.
+ */
+export interface SmrtStiReadScope {
+  types: readonly string[];
 }
 
 export interface SmrtListOptions<ModelType extends SmrtObject> {
@@ -392,6 +406,11 @@ export interface SmrtListOptions<ModelType extends SmrtObject> {
    * Opt-in read-through cache for this call (issue #1498).
    */
   cache?: CollectionCacheConfig | false;
+  /**
+   * Opt in to reading an allowlist of sibling types through an STI child
+   * collection. Omit to retain the child-only discriminator scope.
+   */
+  stiScope?: SmrtStiReadScope;
 }
 
 /**
@@ -561,6 +580,83 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     return (
       registered?.qualifiedName || registered?.name || this._itemClass.name
     );
+  }
+
+  /** Apply and validate this collection's owned STI discriminator predicate. */
+  private applyStiReadScope(
+    where: SmrtListWhereClause<ModelType> | undefined,
+    stiScope: SmrtStiReadScope | undefined,
+  ): SmrtListWhereClause<ModelType> | undefined {
+    const itemQualifiedName = this.getResolvedItemQualifiedName();
+    const isSTI = ObjectRegistry.getTableStrategy(itemQualifiedName) === 'sti';
+    const stiBase = isSTI ? ObjectRegistry.getSTIBase(itemQualifiedName) : null;
+    const isChild = stiBase !== null && stiBase !== itemQualifiedName;
+
+    if (stiScope === undefined) {
+      return isChild
+        ? andWhereCondition(where, { _meta_type: itemQualifiedName })
+        : where;
+    }
+    if (
+      !stiScope ||
+      typeof stiScope !== 'object' ||
+      Array.isArray(stiScope) ||
+      Object.keys(stiScope).some((key) => key !== 'types') ||
+      !Array.isArray(stiScope.types)
+    ) {
+      throw new Error(
+        'Invalid stiScope: expected { types: readonly qualified STI type[] }.',
+      );
+    }
+    if (!isChild) {
+      throw new Error(
+        'Invalid stiScope: explicit discriminator scopes require an STI child collection.',
+      );
+    }
+    if (stiScope.types.length === 0) {
+      throw new Error('Invalid stiScope: types must not be empty.');
+    }
+    if (stiScope.types.length > MAX_STI_READ_SCOPE_TYPES) {
+      throw new Error(
+        `Invalid stiScope: at most ${MAX_STI_READ_SCOPE_TYPES} types are allowed.`,
+      );
+    }
+
+    const seen = new Set<string>();
+    for (const type of stiScope.types) {
+      if (
+        typeof type !== 'string' ||
+        !/^@[a-z0-9][a-z0-9._-]*(?:\/[a-z0-9][a-z0-9._-]*)?:[A-Za-z_$][A-Za-z0-9_$]*$/.test(
+          type,
+        )
+      ) {
+        throw new Error(
+          `Invalid stiScope type: '${String(type)}' must be a qualified SMRT type.`,
+        );
+      }
+      if (seen.has(type)) {
+        throw new Error(`Invalid stiScope: duplicate type '${type}'.`);
+      }
+      seen.add(type);
+
+      const registered = ObjectRegistry.getClass(type);
+      if (!registered || registered.qualifiedName !== type) {
+        throw new Error(`Invalid stiScope: unknown type '${type}'.`);
+      }
+      const typeBase = ObjectRegistry.getSTIBase(type);
+      if (
+        ObjectRegistry.getTableStrategy(type) !== 'sti' ||
+        typeBase !== stiBase
+      ) {
+        throw new Error(
+          `Invalid stiScope: type '${type}' does not share STI root '${stiBase}'.`,
+        );
+      }
+    }
+
+    return andWhereCondition(where, {
+      '_meta_type in': [...stiScope.types],
+    });
   }
 
   /**
@@ -1634,8 +1730,21 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    * ```
    */
   public async listWithLatestRelated(
+    options: Omit<SmrtLatestRelatedListOptions<ModelType>, 'stiScope'> & {
+      stiScope: SmrtStiReadScope;
+    },
+  ): Promise<SmrtLatestRelatedRow<SmrtObject>[]>;
+  public async listWithLatestRelated(
+    options: Omit<SmrtLatestRelatedListOptions<ModelType>, 'stiScope'> & {
+      stiScope?: undefined;
+    },
+  ): Promise<SmrtLatestRelatedRow<ModelType>[]>;
+  public async listWithLatestRelated(
     options: SmrtLatestRelatedListOptions<ModelType>,
-  ): Promise<SmrtLatestRelatedRow<ModelType>[]> {
+  ): Promise<SmrtLatestRelatedRow<SmrtObject>[]>;
+  public async listWithLatestRelated(
+    options: SmrtLatestRelatedListOptions<ModelType>,
+  ): Promise<SmrtLatestRelatedRow<SmrtObject>[]> {
     await this.ensureStorageReady();
     const itemClassName = this.getResolvedItemClassName();
     const itemQualifiedName = this.getResolvedItemQualifiedName();
@@ -1652,19 +1761,14 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
         interceptorContext,
       )) ?? (options as InterceptorListOptions);
 
-    let { where, offset, limit, orderBy } =
+    let { where, offset, limit, orderBy, stiScope } =
       interceptedOptions as SmrtListOptions<ModelType>;
     const latestOptions =
       (interceptedOptions as SmrtLatestRelatedListOptions<ModelType>)
         .latestRelated ?? options.latestRelated;
     const tableStrategy = ObjectRegistry.getTableStrategy(itemQualifiedName);
     const isSTI = tableStrategy === 'sti';
-    if (isSTI) {
-      const stiBase = ObjectRegistry.getSTIBase(itemQualifiedName);
-      if (stiBase && stiBase !== itemQualifiedName) {
-        where = { _meta_type: itemQualifiedName, ...(where || {}) };
-      }
-    }
+    where = this.applyStiReadScope(where, stiScope);
     where = resolveMetaTypeInWhere(where);
 
     const relationship = ObjectRegistry.getRelationships(
@@ -2519,8 +2623,32 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    */
   public async get(
     filter: string | SmrtWhereClause<ModelType>,
-    options: { cache?: CollectionCacheConfig | false } = {},
-  ): Promise<ModelType | null> {
+    options: {
+      cache?: CollectionCacheConfig | false;
+      stiScope: SmrtStiReadScope;
+    },
+  ): Promise<SmrtObject | null>;
+  public async get(
+    filter: string | SmrtWhereClause<ModelType>,
+    options?: {
+      cache?: CollectionCacheConfig | false;
+      stiScope?: undefined;
+    },
+  ): Promise<ModelType | null>;
+  public async get(
+    filter: string | SmrtWhereClause<ModelType>,
+    options?: {
+      cache?: CollectionCacheConfig | false;
+      stiScope?: SmrtStiReadScope;
+    },
+  ): Promise<SmrtObject | null>;
+  public async get(
+    filter: string | SmrtWhereClause<ModelType>,
+    options: {
+      cache?: CollectionCacheConfig | false;
+      stiScope?: SmrtStiReadScope;
+    } = {},
+  ): Promise<SmrtObject | null> {
     await this.ensureStorageReady();
     const itemClassName = this.getResolvedItemClassName();
     const itemQualifiedName = this.getResolvedItemQualifiedName();
@@ -2554,15 +2682,11 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     const tableStrategy = ObjectRegistry.getTableStrategy(itemQualifiedName);
     const isSTI = tableStrategy === 'sti';
 
-    if (isSTI) {
-      const stiBase = ObjectRegistry.getSTIBase(itemQualifiedName);
-      if (stiBase && stiBase !== itemQualifiedName) {
-        where = {
-          _meta_type: itemQualifiedName,
-          ...where,
-        };
-      }
+    const scopedWhere = this.applyStiReadScope(where, options.stiScope);
+    if (Array.isArray(scopedWhere)) {
+      throw new Error('Invalid STI point-read scope.');
     }
+    where = scopedWhere ?? where;
 
     // convertWhereKeys is now sync (issue #663) - no await needed
     const convertedWhere = this.convertWhereKeys(where);
@@ -2659,13 +2783,28 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     },
   ): Promise<SmrtSelectedRow<ModelType, Select>[]>;
   public async list(
-    options?: Omit<SmrtListOptions<ModelType>, 'select'> & {
+    options: Omit<SmrtListOptions<ModelType>, 'select' | 'stiScope'> & {
       select?: undefined;
+      stiScope: SmrtStiReadScope;
+    },
+  ): Promise<SmrtObject[]>;
+  public async list(
+    options?: Omit<SmrtListOptions<ModelType>, 'select' | 'stiScope'> & {
+      select?: undefined;
+      stiScope?: undefined;
     },
   ): Promise<ModelType[]>;
   public async list(
+    options?: Omit<SmrtListOptions<ModelType>, 'select'> & {
+      select?: undefined;
+    },
+  ): Promise<SmrtObject[]>;
+  public async list(
+    options?: SmrtListOptions<ModelType>,
+  ): Promise<SmrtObject[] | Record<string, unknown>[]>;
+  public async list(
     options: SmrtListOptions<ModelType> = {},
-  ): Promise<ModelType[] | Record<string, unknown>[]> {
+  ): Promise<SmrtObject[] | Record<string, unknown>[]> {
     await this.ensureStorageReady();
     const itemClassName = this.getResolvedItemClassName();
     const itemQualifiedName = this.getResolvedItemQualifiedName();
@@ -2685,7 +2824,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       (options as InterceptorListOptions | undefined) ??
       {};
 
-    let { where, offset, limit, orderBy, select } =
+    let { where, offset, limit, orderBy, select, stiScope } =
       interceptedOptions as SmrtListOptions<ModelType>;
 
     // STI: Child collections should automatically filter by _meta_type.
@@ -2694,14 +2833,7 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
     const tableStrategy = ObjectRegistry.getTableStrategy(itemQualifiedName);
     const isSTI = tableStrategy === 'sti';
 
-    if (isSTI) {
-      const stiBase = ObjectRegistry.getSTIBase(itemQualifiedName);
-      if (stiBase && stiBase !== itemQualifiedName) {
-        where = andWhereCondition(where, {
-          _meta_type: itemQualifiedName,
-        });
-      }
-    }
+    where = this.applyStiReadScope(where, stiScope);
 
     // Resolve _meta_type to qualified name if user provided simple class name (Issue #713)
     where = resolveMetaTypeInWhere(where);
@@ -3739,9 +3871,13 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    *
    * @see {@link list} for retrieving the actual records
    */
-  public async count(options: { where?: SmrtListWhereClause<ModelType> } = {}) {
+  public async count(
+    options: {
+      where?: SmrtListWhereClause<ModelType>;
+      stiScope?: SmrtStiReadScope;
+    } = {},
+  ) {
     await this.ensureStorageReady();
-    const itemQualifiedName = this.getResolvedItemQualifiedName();
     const itemClassName = this.getResolvedItemClassName();
 
     // Security (#1540): count() is a list-shaped read, so run the same
@@ -3762,24 +3898,9 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       (options as InterceptorListOptions | undefined) ??
       {};
 
-    let { where } = interceptedOptions;
+    let { where, stiScope } = interceptedOptions as SmrtListOptions<ModelType>;
 
-    // Fix for issue #386: Add _meta_type filter for STI child collections.
-    // R5-canon: qualified-key lookup throughout — pass `itemQualifiedName`
-    // to both `getTableStrategy` and `getSTIBase` so a colliding
-    // simple-name class in another package can't yield the wrong table
-    // strategy / STI base.
-    const tableStrategy = ObjectRegistry.getTableStrategy(itemQualifiedName);
-    const isSTI = tableStrategy === 'sti';
-
-    if (isSTI) {
-      const stiBase = ObjectRegistry.getSTIBase(itemQualifiedName);
-      if (stiBase && stiBase !== itemQualifiedName) {
-        where = andWhereCondition(where, {
-          _meta_type: itemQualifiedName,
-        });
-      }
-    }
+    where = this.applyStiReadScope(where, stiScope);
 
     // Resolve _meta_type to qualified name if user provided simple class name (Issue #713)
     where = resolveMetaTypeInWhere(where);
@@ -3862,18 +3983,10 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
       (options as unknown as InterceptorListOptions) ??
       {};
 
-    let { where } =
+    let { where, stiScope } =
       interceptedOptions as unknown as SmrtFacetOptions<ModelType>;
-    const tableStrategy = ObjectRegistry.getTableStrategy(itemQualifiedName);
-    const isSTI = tableStrategy === 'sti';
-    if (isSTI) {
-      const stiBase = ObjectRegistry.getSTIBase(itemQualifiedName);
-      if (stiBase && stiBase !== itemQualifiedName) {
-        where = andWhereCondition(where, {
-          _meta_type: itemQualifiedName,
-        });
-      }
-    }
+    const isSTI = ObjectRegistry.getTableStrategy(itemQualifiedName) === 'sti';
+    where = this.applyStiReadScope(where, stiScope);
     where = resolveMetaTypeInWhere(where);
 
     const { sql: whereSql, values: whereValues } = buildWhere(
@@ -3978,9 +4091,12 @@ export class SmrtCollection<ModelType extends SmrtObject> extends SmrtClass {
    * count adds the caller's `where` conditions.
    */
   public async counts(
-    options: { where?: SmrtListWhereClause<ModelType> } = {},
+    options: {
+      where?: SmrtListWhereClause<ModelType>;
+      stiScope?: SmrtStiReadScope;
+    } = {},
   ): Promise<SmrtCollectionCounts> {
-    const total = await this.count();
+    const total = await this.count({ stiScope: options.stiScope });
     const filtered = await this.count(options);
     return { total, filtered };
   }

--- a/packages/reports/src/report.ts
+++ b/packages/reports/src/report.ts
@@ -1,8 +1,12 @@
 import {
   ObjectRegistry,
   SmrtCollection,
+  type SmrtListOptions,
   SmrtObject,
   type SmrtObjectOptions,
+  type SmrtSelectedRow,
+  type SmrtSelectField,
+  type SmrtStiReadScope,
 } from '@happyvertical/smrt-core';
 import { toSnakeCase } from '@happyvertical/smrt-core/utils';
 import { getTenantId } from '@happyvertical/smrt-tenancy';
@@ -150,9 +154,38 @@ export class SmrtReportCollection<
     });
   }
 
+  override async list<
+    const Select extends readonly SmrtSelectField<ModelType>[],
+  >(
+    options: SmrtListOptions<ModelType> & {
+      select: Select;
+      include?: never;
+    },
+  ): Promise<SmrtSelectedRow<ModelType, Select>[]>;
   override async list(
-    options: Parameters<SmrtCollection<ModelType>['list']>[0] = {},
-  ): Promise<ModelType[]> {
+    options: Omit<SmrtListOptions<ModelType>, 'select' | 'stiScope'> & {
+      select?: undefined;
+      stiScope: SmrtStiReadScope;
+    },
+  ): Promise<SmrtObject[]>;
+  override async list(options?: undefined): Promise<ModelType[]>;
+  override async list(
+    options: Omit<SmrtListOptions<ModelType>, 'select' | 'stiScope'> & {
+      select?: undefined;
+      stiScope?: undefined;
+    },
+  ): Promise<ModelType[]>;
+  override async list(
+    options:
+      | (Omit<SmrtListOptions<ModelType>, 'select'> & { select?: undefined })
+      | undefined,
+  ): Promise<SmrtObject[]>;
+  override async list(
+    options: SmrtListOptions<ModelType> | undefined,
+  ): Promise<SmrtObject[] | Record<string, unknown>[]>;
+  override async list(
+    options: SmrtListOptions<ModelType> = {},
+  ): Promise<SmrtObject[] | Record<string, unknown>[]> {
     await this.refreshIfStale();
     return super.list(options);
   }

--- a/packages/reports/src/report.ts
+++ b/packages/reports/src/report.ts
@@ -157,9 +157,19 @@ export class SmrtReportCollection<
   override async list<
     const Select extends readonly SmrtSelectField<ModelType>[],
   >(
-    options: SmrtListOptions<ModelType> & {
+    options: Omit<SmrtListOptions<ModelType>, 'select' | 'stiScope'> & {
       select: Select;
       include?: never;
+      stiScope: SmrtStiReadScope;
+    },
+  ): Promise<Record<string, unknown>[]>;
+  override async list<
+    const Select extends readonly SmrtSelectField<ModelType>[],
+  >(
+    options: Omit<SmrtListOptions<ModelType>, 'select' | 'stiScope'> & {
+      select: Select;
+      include?: never;
+      stiScope?: undefined;
     },
   ): Promise<SmrtSelectedRow<ModelType, Select>[]>;
   override async list(


### PR DESCRIPTION
## Summary

- add an explicit bounded `stiScope` allowlist for STI child collection reads
- preserve child-only defaults, tenancy/interceptors, projection, polymorphic hydration, pagination, cache, counts, facets, and latest-related reads
- resolve concrete discriminator field metadata before hydration, including on-demand STI classes, with one metadata resolution per concrete type and result set
- reject malformed, unknown, duplicate, oversized, base, or unrelated scopes at the public boundary
- document the contract and cover SQLite, DuckDB, typed wrapper calls, and an optional PostgreSQL path

## Validation

- focused STI scope suite — 6/6 on SQLite and DuckDB
- latest-related and on-demand hydration regressions — 29/29
- affected Node 24 typecheck closure — 115/115 tasks
- `pnpm --dir packages/core typecheck`
- `pnpm --dir packages/core build`
- `pnpm --dir packages/reports typecheck`
- `pnpm --dir packages/tags typecheck`
- Biome and `git diff --check` on changed files
- independent exact-head code reviews, dedicated QA, and final gate review — approved

The optional PostgreSQL test is present but was skipped locally because no PostgreSQL service or `SMRT_TEST_POSTGRES_URL` is available. Required CI remains authoritative. Browser QA is not applicable to this package-only collection API.

Closes #2513

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-issue-2513-20260825T1042Z",
  "issue": 2513,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "focused STI scope suite: 6/6 SQLite and DuckDB",
    "latest-related and on-demand hydration regressions: 29/29",
    "Node 24 affected typecheck closure: 115/115",
    "pnpm --dir packages/core typecheck",
    "pnpm --dir packages/core build",
    "pnpm --dir packages/reports typecheck",
    "pnpm --dir packages/tags typecheck",
    "independent exact-head code review",
    "dedicated exact-head QA",
    "dedicated exact-head gate review"
  ]
}
```
