### PR TITLE
fix(smrt-web): recover reactive remote query binding

### DIFF
--- a/packages/smrt-svelte/AGENTS.md
+++ b/packages/smrt-svelte/AGENTS.md
@@ -15,6 +15,7 @@ subpath you are editing. This file keeps what holds in every module.
 | `src/test-support/` + `__tests__/` | the golden-test harness and pattern for Svelte component tests | [agents/testing.md](agents/testing.md) |
 | `src/components/settings/` (`./settings`) | `SettingsCatalog`, `paginateSettingsCatalog`, and the summary-vs-detail scalability contract | [agents/settings.md](agents/settings.md) |
 | `src/components/workspace/` (`./workspace` + `./web`) | the AdminShell family and its principles, the legacy ToolsDock surface, the `./web` activity-feed and `updateAvailable` adapters, and server-side dock gates | [agents/workspace.md](agents/workspace.md) |
+| `src/web/remote-query.svelte.ts` | Svelte 5 binding for query-shaped remote pages: rows, page, totals, loading/refreshing/stale/error, retry, last-updated, and query-scoped live subscriptions (#2445) | — |
 
 ## The UI split — primitive-adoption contract (#1589)
 

--- a/packages/smrt-svelte/README.md
+++ b/packages/smrt-svelte/README.md
@@ -70,7 +70,8 @@ hydrating its whole collection. It exposes `rows`, `page`, `total`,
 <script lang="ts">
   import { remoteQuery } from '@happyvertical/smrt-svelte/web';
   const view = remoteQuery(collection, transport);
-  void view.execute(request);
+  // Failures remain available as view.error for reactive rendering.
+  void view.execute(request).catch(() => undefined);
 </script>
 
 {#if view.loading}<p>Loading…</p>{/if}

--- a/packages/smrt-svelte/README.md
+++ b/packages/smrt-svelte/README.md
@@ -60,6 +60,23 @@ state.
 
 ## Usage
 
+### Query-backed data surfaces
+
+Use the web binding when a table should render one remote page instead of
+hydrating its whole collection. It exposes `rows`, `page`, `total`,
+`loading`, `refreshing`, `stale`, `error`, `retry`, and `lastUpdated`.
+
+```svelte
+<script lang="ts">
+  import { remoteQuery } from '@happyvertical/smrt-svelte/web';
+  const view = remoteQuery(collection, transport);
+  void view.execute(request);
+</script>
+
+{#if view.loading}<p>Loading…</p>{/if}
+{#each view.rows as row (row.id)}<div>{row.name}</div>{/each}
+```
+
 ### Provider Setup
 
 ```svelte

--- a/packages/smrt-svelte/src/web/__tests__/remote-query-harness.svelte
+++ b/packages/smrt-svelte/src/web/__tests__/remote-query-harness.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+import type {
+  SmrtWebCollection,
+  SmrtWebQueryTransport,
+} from '@happyvertical/smrt-web';
+import {
+  type RemoteQueryBinding,
+  remoteQuery,
+} from '../remote-query.svelte.js';
+
+interface Props {
+  collection: SmrtWebCollection<Record<string, unknown>>;
+  transport: SmrtWebQueryTransport;
+  onReady: (view: RemoteQueryBinding<Record<string, unknown>>) => void;
+}
+
+const props: Props = $props();
+// The harness intentionally creates one binding for its component lifetime.
+// svelte-ignore state_referenced_locally
+const view = remoteQuery(props.collection, props.transport);
+// svelte-ignore state_referenced_locally
+props.onReady(view);
+</script>
+
+<output data-testid="remote-query-state">
+  {view.request?.requestId ?? 'none'}:{view.rows.map((row) => row.id).join(',')}
+</output>

--- a/packages/smrt-svelte/src/web/__tests__/remote-query.svelte.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/remote-query.svelte.test.ts
@@ -1,0 +1,133 @@
+import {
+  createSmrtCollection,
+  type SmrtWebCollection,
+  type SmrtWebCollectionDefinition,
+  type SmrtWebDataQueryRequest,
+  type SmrtWebQueryTransport,
+} from '@happyvertical/smrt-web';
+import { flushSync, mount, unmount } from 'svelte';
+import { describe, expect, it, vi } from 'vitest';
+import type { RemoteQueryBinding } from '../remote-query.svelte.js';
+import Harness from './remote-query-harness.svelte';
+
+interface Row {
+  id?: string;
+  name: string;
+}
+
+const definition: SmrtWebCollectionDefinition<Row> = {
+  name: 'remote-query-svelte-products',
+  className: 'Product',
+  endpoint: '/products',
+  idField: 'id',
+  actions: ['list'],
+  fields: { name: { type: 'text' } },
+};
+const request: SmrtWebDataQueryRequest = {
+  version: 1,
+  requestId: 'svelte-request',
+  mode: 'rows',
+  page: { kind: 'offset', offset: 0, limit: 10 },
+};
+
+function envelope(received: SmrtWebDataQueryRequest, name: string) {
+  return {
+    version: 1,
+    requestId: received.requestId,
+    queryFingerprint: 'dq1_svelte_products',
+    identityField: 'id',
+    rows: [{ id: name, name }],
+    page: { kind: 'offset', offset: 0, limit: 10, hasMore: false },
+    total: { kind: 'exact', value: 1 },
+    freshness: { state: 'fresh' },
+    warnings: [],
+    truncated: false,
+  };
+}
+
+function mountView(
+  collection: SmrtWebCollection<Row>,
+  transport: SmrtWebQueryTransport,
+): {
+  target: HTMLDivElement;
+  view: RemoteQueryBinding<Row>;
+  teardown: () => void;
+} {
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  let view = undefined as unknown as RemoteQueryBinding<Row>;
+  const component = mount(Harness, {
+    target,
+    props: {
+      collection: collection as unknown as SmrtWebCollection<
+        Record<string, unknown>
+      >,
+      transport,
+      onReady: (next: RemoteQueryBinding<Record<string, unknown>>) => {
+        view = next as unknown as RemoteQueryBinding<Row>;
+      },
+    },
+  });
+  return {
+    target,
+    view,
+    teardown: () => {
+      unmount(component);
+      target.remove();
+    },
+  };
+}
+
+describe('remoteQuery', () => {
+  it('renders request and rows reactively through the Svelte binding', async () => {
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const mounted = mountView(collection, {
+      query: async (received) => envelope(received, 'Ada'),
+    });
+
+    await mounted.view.execute(request);
+    flushSync();
+
+    expect(mounted.target.textContent).toContain('svelte-request:Ada');
+    mounted.teardown();
+    await collection.cleanup();
+  });
+
+  it('disposes an in-flight refresh and live subscription when unmounted', async () => {
+    let calls = 0;
+    let unsubscribed = false;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const mounted = mountView(collection, {
+      query: async (received, options) => {
+        calls += 1;
+        if (calls === 1) return envelope(received, 'initial');
+        return await new Promise<never>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            'abort',
+            () => reject(options.signal?.reason),
+            { once: true },
+          );
+        });
+      },
+      subscribe: () => ({
+        unsubscribe: () => {
+          unsubscribed = true;
+        },
+      }),
+    });
+
+    await mounted.view.execute(request);
+    mounted.view.subscribeLive();
+    const refresh = mounted.view.refresh();
+    await vi.waitFor(() => expect(calls).toBe(2));
+    mounted.teardown();
+
+    await expect(refresh).rejects.toMatchObject({ name: 'AbortError' });
+    expect(unsubscribed).toBe(true);
+    await collection.cleanup();
+  });
+});

--- a/packages/smrt-svelte/src/web/index.ts
+++ b/packages/smrt-svelte/src/web/index.ts
@@ -30,6 +30,12 @@ export {
   liveCollection,
 } from './live-collection.svelte.js';
 export {
+  createRemoteQueryBinding,
+  queryBinding,
+  type RemoteQueryBinding,
+  remoteQuery,
+} from './remote-query.svelte.js';
+export {
   type UpdateAvailableView,
   type UseUpdateAvailableOptions,
   useUpdateAvailable,

--- a/packages/smrt-svelte/src/web/index.ts
+++ b/packages/smrt-svelte/src/web/index.ts
@@ -30,8 +30,6 @@ export {
   liveCollection,
 } from './live-collection.svelte.js';
 export {
-  createRemoteQueryBinding,
-  queryBinding,
   type RemoteQueryBinding,
   remoteQuery,
 } from './remote-query.svelte.js';

--- a/packages/smrt-svelte/src/web/remote-query.svelte.ts
+++ b/packages/smrt-svelte/src/web/remote-query.svelte.ts
@@ -1,0 +1,100 @@
+import {
+  createSmrtWebQuery,
+  type SmrtWebCollection,
+  type SmrtWebDataQueryRequest,
+  type SmrtWebDataQueryResult,
+  type SmrtWebQuery,
+  type SmrtWebQueryLiveSubscription,
+  type SmrtWebQueryRunOptions,
+  type SmrtWebQueryState,
+  type SmrtWebQueryTransport,
+} from '@happyvertical/smrt-web';
+
+export interface RemoteQueryBinding<TData extends object = object> {
+  readonly rows: ReadonlyArray<TData>;
+  readonly page: SmrtWebQueryState<TData>['page'];
+  readonly total: SmrtWebQueryState<TData>['total'];
+  readonly loading: boolean;
+  readonly refreshing: boolean;
+  readonly stale: boolean;
+  readonly error: unknown;
+  readonly lastUpdated: number | undefined;
+  readonly request: SmrtWebDataQueryRequest | undefined;
+  execute(
+    request: SmrtWebDataQueryRequest,
+    options?: SmrtWebQueryRunOptions,
+  ): Promise<SmrtWebDataQueryResult>;
+  refresh(
+    options?: Omit<SmrtWebQueryRunOptions, 'mode' | 'force'>,
+  ): Promise<SmrtWebDataQueryResult | undefined>;
+  retry(): Promise<SmrtWebDataQueryResult | undefined>;
+  subscribeLive(): SmrtWebQueryLiveSubscription | undefined;
+  dispose(): void;
+}
+
+/**
+ * Bind a canonical remote query to Svelte 5 state. The binding is query
+ * shaped: rows are only the requested page and never the entire collection.
+ * Call during component initialization so cleanup follows the component.
+ */
+export function remoteQuery<TData extends object>(
+  collection: SmrtWebCollection<TData>,
+  transport: SmrtWebQueryTransport,
+  options?: { staleTimeMs?: number },
+): RemoteQueryBinding<TData> {
+  const query: SmrtWebQuery<TData> = createSmrtWebQuery(
+    collection,
+    transport,
+    options,
+  );
+  let snapshot = $state<SmrtWebQueryState<TData>>(query.state);
+  const unsubscribe = query.subscribe((next) => {
+    snapshot = next;
+  });
+  $effect(() => () => {
+    unsubscribe();
+    query.dispose();
+  });
+  const binding: RemoteQueryBinding<TData> = {
+    get rows() {
+      return snapshot.rows;
+    },
+    get page() {
+      return snapshot.page;
+    },
+    get total() {
+      return snapshot.total;
+    },
+    get loading() {
+      return snapshot.loading;
+    },
+    get refreshing() {
+      return snapshot.refreshing;
+    },
+    get stale() {
+      return snapshot.stale;
+    },
+    get error() {
+      return snapshot.error;
+    },
+    get lastUpdated() {
+      return snapshot.lastUpdated;
+    },
+    get request() {
+      return query.request;
+    },
+    execute: (request, runOptions) => query.execute(request, runOptions),
+    refresh: (runOptions) => query.refresh(runOptions),
+    retry: () => query.retry(),
+    subscribeLive: () => query.subscribeLive(),
+    dispose: () => {
+      unsubscribe();
+      query.dispose();
+    },
+  };
+  return binding;
+}
+
+/** Explicit alias for consumers that prefer the data-source terminology. */
+export const createRemoteQueryBinding = remoteQuery;
+export const queryBinding = remoteQuery;

--- a/packages/smrt-svelte/src/web/remote-query.svelte.ts
+++ b/packages/smrt-svelte/src/web/remote-query.svelte.ts
@@ -48,8 +48,12 @@ export function remoteQuery<TData extends object>(
     options,
   );
   let snapshot = $state<SmrtWebQueryState<TData>>(query.state);
+  let activeRequest = $state<SmrtWebDataQueryRequest | undefined>(
+    query.request,
+  );
   const unsubscribe = query.subscribe((next) => {
     snapshot = next;
+    activeRequest = query.request;
   });
   $effect(() => () => {
     unsubscribe();
@@ -81,7 +85,7 @@ export function remoteQuery<TData extends object>(
       return snapshot.lastUpdated;
     },
     get request() {
-      return query.request;
+      return activeRequest;
     },
     execute: (request, runOptions) => query.execute(request, runOptions),
     refresh: (runOptions) => query.refresh(runOptions),

--- a/packages/smrt-svelte/src/web/remote-query.svelte.ts
+++ b/packages/smrt-svelte/src/web/remote-query.svelte.ts
@@ -94,7 +94,3 @@ export function remoteQuery<TData extends object>(
   };
   return binding;
 }
-
-/** Explicit alias for consumers that prefer the data-source terminology. */
-export const createRemoteQueryBinding = remoteQuery;
-export const queryBinding = remoteQuery;

--- a/packages/smrt-web/AGENTS.md
+++ b/packages/smrt-web/AGENTS.md
@@ -41,6 +41,7 @@ module you are editing. This file keeps what holds in every module.
 | `webmcp.ts` | framework-agnostic WebMCP registrar; registers generated collection tools and routes mutations through shared smrt-web cache state | — |
 | `persistence/` + `update-state.ts` | the read-cache rehydrate capability and the framework-free `updateAvailable` primitive (bundle + contract signals) | [agents/version-persistence.md](agents/version-persistence.md) |
 | `data-query.ts` | dependency-free browser mirror and defensive response normalizer for the canonical bounded data-query envelope (#2444) | — |
+| `remote-query.ts` | query-shaped remote pages over a `SmrtWebCollection`, with keyed stale cache, execution modes, cancellation/latest-query-wins, and optional query-scoped live subscriptions (#2445) | — |
 
 ## The engine-absorption boundary (ratified conditions, #1761)
 

--- a/packages/smrt-web/README.md
+++ b/packages/smrt-web/README.md
@@ -125,7 +125,7 @@ core.
 | Group | Main exports |
 | --- | --- |
 | Collections | `createSmrtCollection`, `createSmrtWebClient`, `newLocalId` |
-| Remote queries | `createSmrtWebQuery`, `createSmrtDataQuery`, `SmrtWebQueryTransport` |
+| Remote queries | `createSmrtWebQuery`, `SmrtWebQueryTransport` |
 | HTTP | `createDefinitionFetchers`, `unwrapListResult`, `unwrapItemResult` |
 | Offline | `offlineOutbox`, `getOutboxHandle` |
 | Persistence | `persistCollection`, `wipeDurableStore` |

--- a/packages/smrt-web/README.md
+++ b/packages/smrt-web/README.md
@@ -9,6 +9,12 @@ Use it for browser-side collection state, shared request deduplication, offline
 writes, persisted read caches, and live invalidation. Svelte bindings live in
 [`@happyvertical/smrt-svelte/web`](../smrt-svelte/README.md).
 
+Query-backed surfaces can use `createSmrtWebQuery(collection, transport)` to
+fetch one canonical bounded page. Visible runs update state; `background`,
+`prefetch`, and `silent` runs stay out of visible state. The controller keeps
+stale rows available while refreshing, cancels superseded visible runs, and can
+attach a query-scoped live subscription.
+
 ## Installation
 
 ```bash
@@ -119,6 +125,7 @@ core.
 | Group | Main exports |
 | --- | --- |
 | Collections | `createSmrtCollection`, `createSmrtWebClient`, `newLocalId` |
+| Remote queries | `createSmrtWebQuery`, `createSmrtDataQuery`, `SmrtWebQueryTransport` |
 | HTTP | `createDefinitionFetchers`, `unwrapListResult`, `unwrapItemResult` |
 | Offline | `offlineOutbox`, `getOutboxHandle` |
 | Persistence | `persistCollection`, `wipeDurableStore` |

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -121,6 +121,20 @@ export {
   DEFAULT_PERSIST_DEBOUNCE_MS,
   persistCollection,
 } from './persistence.js';
+export type {
+  SmrtWebQuery,
+  SmrtWebQueryLiveSubscription,
+  SmrtWebQueryMode,
+  SmrtWebQueryPage,
+  SmrtWebQueryRunOptions,
+  SmrtWebQueryState,
+  SmrtWebQueryTransport,
+} from './remote-query.js';
+export {
+  createSmrtDataQuery,
+  createSmrtQuery,
+  createSmrtWebQuery,
+} from './remote-query.js';
 // Live-updates subscriber (#1763-client): the ONE app-wide SSE `_events`
 // subscriber (with `_changes` polling fallback) and the thin per-collection
 // `liveInvalidation` capability that wires a collection's `ctx.invalidate()` to

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -130,11 +130,7 @@ export type {
   SmrtWebQueryState,
   SmrtWebQueryTransport,
 } from './remote-query.js';
-export {
-  createSmrtDataQuery,
-  createSmrtQuery,
-  createSmrtWebQuery,
-} from './remote-query.js';
+export { createSmrtWebQuery } from './remote-query.js';
 // Live-updates subscriber (#1763-client): the ONE app-wide SSE `_events`
 // subscriber (with `_changes` polling fallback) and the thin per-collection
 // `liveInvalidation` capability that wires a collection's `ctx.invalidate()` to

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -333,4 +333,33 @@ describe('remote query controller', () => {
     query.dispose();
     await collection.cleanup();
   });
+
+  it('rejects a delayed transport result after its signal is aborted', async () => {
+    const caller = new AbortController();
+    let release!: (result: unknown) => void;
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        calls += 1;
+        if (calls > 1) return envelope(received, 'cancelled');
+        return await new Promise<unknown>((resolve) => {
+          release = resolve;
+        });
+      },
+    });
+    const pending = query.execute(request, { signal: caller.signal });
+    caller.abort();
+    release(envelope(request, 'cancelled'));
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(query.state.rows).toEqual([]);
+
+    await query.execute(request);
+    expect(calls).toBe(2);
+    expect(query.state.rows[0]?.name).toBe('cancelled');
+    query.dispose();
+    await collection.cleanup();
+  });
 });

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -642,6 +642,31 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('rebinds a same-key live update to the current request id', async () => {
+    let onResult: ((value: unknown) => void) | undefined;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => envelope(received, 'initial'),
+      subscribe: (_received, callback) => {
+        onResult = callback;
+        return { unsubscribe: () => undefined };
+      },
+    });
+    const newerRequest = { ...request, requestId: 'request-2' };
+
+    await query.execute(request);
+    query.subscribeLive();
+    await query.execute(newerRequest);
+    onResult?.(envelope(request, 'live'));
+
+    await vi.waitFor(() => expect(query.state.rows[0]?.name).toBe('live'));
+    expect(query.state.result?.requestId).toBe('request-2');
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('refetches before fallback reconnect, resubscribes, and ignores old callbacks', async () => {
     const callbacks: Array<(value: unknown) => void> = [];
     let queryCalls = 0;
@@ -682,6 +707,49 @@ describe('remote query controller', () => {
     callbacks[1]?.(envelope(request, 'late-disposed'));
     await Promise.resolve();
     expect(query.state.rows[0]?.name).toBe('reconnected');
+    await collection.cleanup();
+  });
+
+  it('coalesces overlapping reconnects into one replacement subscription', async () => {
+    const callbacks: Array<(value: unknown) => void> = [];
+    const resolveRefreshes: Array<
+      (result: ReturnType<typeof envelope>) => void
+    > = [];
+    let queryCalls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        queryCalls += 1;
+        if (queryCalls === 1) return envelope(received, 'initial');
+        return await new Promise<ReturnType<typeof envelope>>((resolve) => {
+          resolveRefreshes.push(resolve);
+        });
+      },
+      subscribe: (_received, callback) => {
+        callbacks.push(callback);
+        return { unsubscribe: () => undefined };
+      },
+    });
+
+    await query.execute(request);
+    const live = query.subscribeLive();
+    live?.reconnect();
+    live?.reconnect();
+    await vi.waitFor(() => expect(queryCalls).toBe(3));
+    resolveRefreshes[0]?.(envelope(request, 'first-reconnect'));
+    await Promise.resolve();
+    expect(callbacks).toHaveLength(1);
+    resolveRefreshes[1]?.(envelope(request, 'second-reconnect'));
+    await vi.waitFor(() => expect(callbacks).toHaveLength(2));
+
+    callbacks[1]?.(envelope(request, 'reconnected'));
+    await vi.waitFor(() =>
+      expect(query.state.rows[0]?.name).toBe('reconnected'),
+    );
+    live?.unsubscribe();
+    query.dispose();
     await collection.cleanup();
   });
 

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -275,6 +275,77 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('keeps a live result newer than an older forced flight', async () => {
+    let resolveOld!: (result: unknown) => void;
+    let onLive: ((value: unknown) => void) | undefined;
+    let queryCalls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        queryCalls += 1;
+        if (queryCalls === 1) return envelope(received, 'initial');
+        return await new Promise((resolve) => {
+          resolveOld = resolve;
+        });
+      },
+      subscribe: (_received, callback) => {
+        onLive = callback;
+        return { unsubscribe: () => undefined };
+      },
+    });
+    await query.execute(request);
+    query.subscribeLive();
+    const oldFlight = query.execute(request, {
+      mode: 'background',
+      force: true,
+    });
+    await vi.waitFor(() => expect(queryCalls).toBe(2));
+    onLive?.(envelope(request, 'live'));
+    await vi.waitFor(() => expect(query.state.rows[0]?.name).toBe('live'));
+    resolveOld(envelope(request, 'old'));
+    await oldFlight;
+
+    await query.execute(request);
+    expect(queryCalls).toBe(2);
+    expect(query.state.rows[0]?.name).toBe('live');
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('does not let a pending flight repopulate cache after dispose', async () => {
+    let resolvePending!: (result: unknown) => void;
+    let queryCalls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        queryCalls += 1;
+        if (queryCalls === 1) return envelope(received, 'initial');
+        if (queryCalls === 2) {
+          return await new Promise((resolve) => {
+            resolvePending = resolve;
+          });
+        }
+        return envelope(received, 'after-dispose');
+      },
+    });
+    await query.execute(request);
+    const pending = query.refresh();
+    await vi.waitFor(() => expect(queryCalls).toBe(2));
+    query.dispose();
+    resolvePending(envelope(request, 'disposed-flight'));
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(query.state.rows[0]?.name).toBe('initial');
+
+    await query.execute(request, { mode: 'background' });
+    expect(queryCalls).toBe(3);
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('prefetches into the keyed cache without changing visible state, then refreshes coherently', async () => {
     let value = 'prefetched';
     const collection = createSmrtCollection(definition, {

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -691,6 +691,47 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('replaces an active live subscription for a different visible query', async () => {
+    const subscriptions: Array<{
+      request: SmrtWebDataQueryRequest;
+      callback: (value: unknown) => void;
+    }> = [];
+    let unsubscribed = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => envelope(received, 'initial'),
+      subscribe: (received, callback) => {
+        subscriptions.push({ request: received, callback });
+        return {
+          unsubscribe: () => {
+            unsubscribed += 1;
+          },
+        };
+      },
+    });
+    const nextRequest = {
+      ...request,
+      requestId: 'request-2',
+      page: { kind: 'offset' as const, offset: 10, limit: 10 },
+    };
+
+    await query.execute(request);
+    query.subscribeLive();
+    await query.execute(nextRequest);
+
+    expect(unsubscribed).toBe(1);
+    expect(subscriptions).toHaveLength(2);
+    expect(subscriptions[1]?.request).toEqual(nextRequest);
+    subscriptions[0]?.callback(envelope(request, 'old-live'));
+    subscriptions[1]?.callback(envelope(nextRequest, 'new-live'));
+
+    await vi.waitFor(() => expect(query.state.rows[0]?.name).toBe('new-live'));
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('does not let a delayed live update overtake a newer explicit fetch', async () => {
     let onResult: ((value: unknown) => void) | undefined;
     let resolveLive!: (result: ReturnType<typeof envelope>) => void;

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -139,6 +139,73 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('keeps shared transport alive when its initiating caller cancels', async () => {
+    const caller = new AbortController();
+    let resolveQuery!: (result: ReturnType<typeof envelope>) => void;
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        calls += 1;
+        return await new Promise<ReturnType<typeof envelope>>((resolve) => {
+          resolveQuery = resolve;
+          void received;
+        });
+      },
+    });
+
+    const first = query.execute(request, {
+      mode: 'background',
+      signal: caller.signal,
+    });
+    const second = query.execute(
+      { ...request, requestId: 'request-2' },
+      { mode: 'background' },
+    );
+    caller.abort();
+
+    await expect(first).rejects.toMatchObject({ name: 'AbortError' });
+    resolveQuery(envelope(request, 'shared'));
+    await expect(second).resolves.toMatchObject({
+      requestId: 'request-2',
+    });
+    expect(calls).toBe(1);
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('applies a joining caller deadline without cancelling shared transport', async () => {
+    let resolveQuery!: (result: ReturnType<typeof envelope>) => void;
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        calls += 1;
+        return await new Promise<ReturnType<typeof envelope>>((resolve) => {
+          resolveQuery = resolve;
+          void received;
+        });
+      },
+    });
+
+    const first = query.execute(request, { mode: 'background' });
+    const joining = query.execute(
+      { ...request, requestId: 'request-2' },
+      { mode: 'background', deadlineMs: 1 },
+    );
+
+    await expect(joining).rejects.toMatchObject({ name: 'AbortError' });
+    resolveQuery(envelope(request, 'shared'));
+    await expect(first).resolves.toMatchObject({ requestId: 'request-1' });
+    expect(calls).toBe(1);
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('releases visible refresh state when a background successor wins the cache', async () => {
     let resolveRefresh!: (result: ReturnType<typeof envelope>) => void;
     let calls = 0;

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -109,6 +109,39 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('releases visible refresh state when a background successor wins the cache', async () => {
+    let resolveRefresh!: (result: ReturnType<typeof envelope>) => void;
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        calls += 1;
+        if (calls === 1) return envelope(received, 'initial');
+        if (calls === 2) {
+          return await new Promise<ReturnType<typeof envelope>>((resolve) => {
+            resolveRefresh = resolve;
+          });
+        }
+        return envelope(received, 'background');
+      },
+    });
+
+    await query.execute(request);
+    const refresh = query.refresh();
+    await vi.waitFor(() => expect(calls).toBe(2));
+    await query.execute(request, { mode: 'background', force: true });
+    resolveRefresh(envelope(request, 'older-refresh'));
+    await refresh;
+
+    expect(query.state.rows[0]?.name).toBe('initial');
+    expect(query.state.loading).toBe(false);
+    expect(query.state.refreshing).toBe(false);
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('suppresses an older visible response and never exposes its error', async () => {
     let releaseFirst!: () => void;
     const first = new Promise<void>((resolve) => {

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createSmrtCollection,
+  createSmrtWebQuery,
+  type SmrtWebCollectionDefinition,
+  type SmrtWebDataQueryRequest,
+} from './index.js';
+
+interface Row {
+  id?: string;
+  name: string;
+}
+
+const definition: SmrtWebCollectionDefinition<Row> = {
+  name: 'remote-products',
+  className: 'Product',
+  endpoint: '/products',
+  idField: 'id',
+  actions: ['list'],
+  fields: { name: { type: 'text' } },
+};
+const request: SmrtWebDataQueryRequest = {
+  version: 1,
+  requestId: 'request-1',
+  mode: 'rows',
+  page: { kind: 'offset', offset: 0, limit: 10 },
+};
+
+function envelope(received: SmrtWebDataQueryRequest, name: string) {
+  return {
+    version: 1,
+    requestId: received.requestId,
+    queryFingerprint: 'dq1_products',
+    identityField: 'id',
+    rows: [{ id: name, name }],
+    page: { kind: 'offset', offset: 0, limit: 10, hasMore: false },
+    total: { kind: 'exact', value: 1 },
+    freshness: { state: 'fresh' },
+    warnings: [],
+    truncated: false,
+  };
+}
+
+describe('remote query controller', () => {
+  it('loads one page without hydrating the base collection and exposes table state', async () => {
+    let listCalls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: {
+        list: async () => {
+          listCalls += 1;
+          return [];
+        },
+        create: async () => ({}),
+      },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => envelope(received, 'Ada'),
+    });
+
+    await query.execute(request);
+    expect(listCalls).toBe(0);
+    expect(query.state.rows).toEqual([{ id: 'Ada', name: 'Ada' }]);
+    expect(query.state.page?.kind).toBe('offset');
+    expect(query.state.total).toEqual({ kind: 'exact', value: 1 });
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('suppresses an older visible response and never exposes its error', async () => {
+    let releaseFirst!: () => void;
+    const first = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let call = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        call += 1;
+        if (call === 1) await first;
+        return envelope(received, call === 1 ? 'old' : 'new');
+      },
+    });
+    const older = query.execute(request).catch(() => undefined);
+    const newerRequest = {
+      ...request,
+      requestId: 'request-2',
+      page: { kind: 'offset' as const, offset: 10, limit: 10 },
+    };
+    await query.execute(newerRequest);
+    releaseFirst();
+    await older;
+    expect(query.state.rows).toEqual([{ id: 'new', name: 'new' }]);
+    expect(query.state.error).toBeNull();
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('prefetches into the keyed cache without changing visible state, then refreshes coherently', async () => {
+    let value = 'prefetched';
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => envelope(received, value),
+    });
+    await query.execute(request, { mode: 'prefetch' });
+    expect(query.state.rows).toEqual([]);
+    await query.execute(request);
+    expect(query.state.rows[0]?.name).toBe('prefetched');
+    value = 'fresh';
+    await query.refresh();
+    expect(query.state.rows[0]?.name).toBe('fresh');
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('subscribes to the exact query and applies matching live pages', async () => {
+    let onResult: ((value: unknown) => void) | undefined;
+    let unsubscribed = false;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => envelope(received, 'initial'),
+      subscribe: (received, callback) => {
+        expect(received.page).toEqual(request.page);
+        onResult = callback;
+        return {
+          unsubscribe: () => {
+            unsubscribed = true;
+          },
+        };
+      },
+    });
+    await query.execute(request);
+    const live = query.subscribeLive();
+    onResult?.(envelope(request, 'live'));
+    await vi.waitFor(() => expect(query.state.rows[0]?.name).toBe('live'));
+    live?.unsubscribe();
+    expect(unsubscribed).toBe(true);
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('passes deadline cancellation through without surfacing an abort as a query error', async () => {
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (_received, options) => {
+        if (options?.signal?.aborted) throw options.signal.reason;
+        return await new Promise<never>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            'abort',
+            () => reject(options.signal?.reason),
+            { once: true },
+          );
+        });
+      },
+    });
+    await expect(
+      query.execute(request, { deadlineMs: 0 }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(query.state.error).toBeNull();
+    query.dispose();
+    await collection.cleanup();
+  });
+});

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -778,7 +778,7 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
-  it('reports a failed reconnect bind without an unhandled rejection', async () => {
+  it('reports a failed bind after a successful reconnect resync', async () => {
     const liveError = new Error('reconnect unavailable');
     let failReconnect = false;
     const collection = createSmrtCollection(definition, {
@@ -799,6 +799,37 @@ describe('remote query controller', () => {
 
     await vi.waitFor(() => expect(query.state.error).toBe(liveError));
     expect(query.state.rows[0]?.name).toBe('refreshed');
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('contains a failed reconnect fallback bind after a rejected resync', async () => {
+    const refreshError = new Error('resync unavailable');
+    const liveError = new Error('reconnect unavailable');
+    let failRefresh = false;
+    let failReconnect = false;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        if (failRefresh) throw refreshError;
+        return envelope(received, 'initial');
+      },
+      subscribe: () => {
+        if (failReconnect) throw liveError;
+        return { unsubscribe: () => undefined };
+      },
+    });
+
+    await query.execute(request);
+    const live = query.subscribeLive();
+    failRefresh = true;
+    failReconnect = true;
+    live?.reconnect();
+
+    await vi.waitFor(() => expect(query.state.error).toBe(liveError));
+    expect(query.state.rows[0]?.name).toBe('initial');
     query.dispose();
     await collection.cleanup();
   });

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -329,6 +329,41 @@ describe('remote query controller', () => {
     await expect(
       query.execute(request, { deadlineMs: 0 }),
     ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(query.state.loading).toBe(false);
+    expect(query.state.refreshing).toBe(false);
+    expect(query.state.error).toBeNull();
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('clears refreshing after the current refresh is cancelled', async () => {
+    const caller = new AbortController();
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received, options) => {
+        calls += 1;
+        if (calls === 1) return envelope(received, 'cached');
+        return await new Promise<never>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            'abort',
+            () => reject(options.signal?.reason),
+            { once: true },
+          );
+        });
+      },
+    });
+    await query.execute(request);
+    const pending = query.refresh({ signal: caller.signal });
+    await vi.waitFor(() => expect(query.state.refreshing).toBe(true));
+    caller.abort();
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(query.state.rows[0]?.name).toBe('cached');
+    expect(query.state.loading).toBe(false);
+    expect(query.state.refreshing).toBe(false);
+    expect(query.state.stale).toBe(true);
     expect(query.state.error).toBeNull();
     query.dispose();
     await collection.cleanup();

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -796,6 +796,87 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('lets the original live handle cancel a pending query rebind', async () => {
+    const subscriptions: SmrtWebDataQueryRequest[] = [];
+    let resolveQuery!: (result: ReturnType<typeof envelope>) => void;
+    let calls = 0;
+    let unsubscribed = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        calls += 1;
+        if (calls === 1) return envelope(received, 'initial');
+        return await new Promise<ReturnType<typeof envelope>>((resolve) => {
+          resolveQuery = resolve;
+        });
+      },
+      subscribe: (received) => {
+        subscriptions.push(received);
+        return {
+          unsubscribe: () => {
+            unsubscribed += 1;
+          },
+        };
+      },
+    });
+    const nextRequest = {
+      ...request,
+      requestId: 'request-2',
+      page: { kind: 'offset' as const, offset: 10, limit: 10 },
+    };
+
+    await query.execute(request);
+    const live = query.subscribeLive();
+    const next = query.execute(nextRequest);
+    await vi.waitFor(() => expect(calls).toBe(2));
+    live?.unsubscribe();
+    resolveQuery(envelope(nextRequest, 'next'));
+    await next;
+
+    expect(unsubscribed).toBe(1);
+    expect(subscriptions).toEqual([request]);
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('disconnects a transport only once during repeated reconnects', async () => {
+    const callbacks: Array<(value: unknown) => void> = [];
+    let calls = 0;
+    let unsubscribeCalls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        calls += 1;
+        return envelope(received, calls === 1 ? 'initial' : 'reconnected');
+      },
+      subscribe: (_received, callback) => {
+        callbacks.push(callback);
+        let closed = false;
+        return {
+          unsubscribe: () => {
+            if (closed) throw new Error('subscription closed twice');
+            closed = true;
+            unsubscribeCalls += 1;
+          },
+        };
+      },
+    });
+
+    await query.execute(request);
+    const live = query.subscribeLive();
+    live?.reconnect();
+    live?.reconnect();
+    await vi.waitFor(() => expect(callbacks).toHaveLength(2));
+
+    expect(unsubscribeCalls).toBe(1);
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('does not let a delayed live update overtake a newer explicit fetch', async () => {
     let onResult: ((value: unknown) => void) | undefined;
     let resolveLive!: (result: ReturnType<typeof envelope>) => void;
@@ -916,9 +997,7 @@ describe('remote query controller', () => {
 
   it('coalesces overlapping reconnects into one replacement subscription', async () => {
     const callbacks: Array<(value: unknown) => void> = [];
-    const resolveRefreshes: Array<
-      (result: ReturnType<typeof envelope>) => void
-    > = [];
+    let resolveRefresh!: (result: ReturnType<typeof envelope>) => void;
     let queryCalls = 0;
     const collection = createSmrtCollection(definition, {
       fetchers: { list: async () => [], create: async () => ({}) },
@@ -928,7 +1007,7 @@ describe('remote query controller', () => {
         queryCalls += 1;
         if (queryCalls === 1) return envelope(received, 'initial');
         return await new Promise<ReturnType<typeof envelope>>((resolve) => {
-          resolveRefreshes.push(resolve);
+          resolveRefresh = resolve;
         });
       },
       subscribe: (_received, callback) => {
@@ -941,11 +1020,8 @@ describe('remote query controller', () => {
     const live = query.subscribeLive();
     live?.reconnect();
     live?.reconnect();
-    await vi.waitFor(() => expect(queryCalls).toBe(3));
-    resolveRefreshes[0]?.(envelope(request, 'first-reconnect'));
-    await Promise.resolve();
-    expect(callbacks).toHaveLength(1);
-    resolveRefreshes[1]?.(envelope(request, 'second-reconnect'));
+    await vi.waitFor(() => expect(queryCalls).toBe(2));
+    resolveRefresh(envelope(request, 'reconnect'));
     await vi.waitFor(() => expect(callbacks).toHaveLength(2));
 
     callbacks[1]?.(envelope(request, 'reconnected'));

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -624,6 +624,65 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('does not resurrect a query when a superseded run disposes it', async () => {
+    let calls = 0;
+    let query!: ReturnType<typeof createSmrtWebQuery<Row>>;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    query = createSmrtWebQuery(collection, {
+      query: async (_received, options) => {
+        calls += 1;
+        return await new Promise<never>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            'abort',
+            () => {
+              query.dispose();
+              reject(options.signal?.reason);
+            },
+            { once: true },
+          );
+        });
+      },
+    });
+
+    const first = query.execute(request).catch(() => undefined);
+    await vi.waitFor(() => expect(calls).toBe(1));
+    await expect(
+      query.execute({ ...request, requestId: 'request-2' }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    await first;
+
+    expect(calls).toBe(1);
+    expect(query.request).toBeUndefined();
+    await collection.cleanup();
+  });
+
+  it('does not start transport after a state listener disposes the query', async () => {
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        calls += 1;
+        return envelope(received, 'unexpected');
+      },
+    });
+    const unsubscribe = query.subscribe((next) => {
+      if (next.loading) query.dispose();
+    });
+
+    await expect(query.execute(request)).rejects.toMatchObject({
+      name: 'AbortError',
+    });
+
+    expect(calls).toBe(0);
+    expect(query.request).toBeUndefined();
+    unsubscribe();
+    await collection.cleanup();
+  });
+
   it('prefetches into the keyed cache without changing visible state, then refreshes coherently', async () => {
     let value = 'prefetched';
     const collection = createSmrtCollection(definition, {

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -66,6 +66,49 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('shares equivalent query keys and rebinds a cached result to the current request id', async () => {
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        calls += 1;
+        return envelope(received, 'cached');
+      },
+    });
+    const first: SmrtWebDataQueryRequest = {
+      ...request,
+      filter: {
+        kind: 'condition',
+        field: 'name',
+        operator: 'eq',
+        value: 'Ada',
+      },
+    };
+    const equivalent: SmrtWebDataQueryRequest = {
+      mode: 'rows',
+      filter: {
+        value: 'Ada',
+        operator: 'eq',
+        field: 'name',
+        kind: 'condition',
+      },
+      page: { limit: 10, offset: 0, kind: 'offset' },
+      requestId: 'request-2',
+      version: 1,
+    };
+
+    await query.execute(first);
+    const cached = await query.execute(equivalent);
+
+    expect(calls).toBe(1);
+    expect(cached.requestId).toBe('request-2');
+    expect(query.state.result?.requestId).toBe('request-2');
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('suppresses an older visible response and never exposes its error', async () => {
     let releaseFirst!: () => void;
     const first = new Promise<void>((resolve) => {
@@ -314,6 +357,41 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('does not let a current visible refresh overwrite a newer live result', async () => {
+    let resolveRefresh!: (result: unknown) => void;
+    let onLive: ((value: unknown) => void) | undefined;
+    let queryCalls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        queryCalls += 1;
+        if (queryCalls === 1) return envelope(received, 'initial');
+        return await new Promise((resolve) => {
+          resolveRefresh = resolve;
+        });
+      },
+      subscribe: (_received, callback) => {
+        onLive = callback;
+        return { unsubscribe: () => undefined };
+      },
+    });
+
+    await query.execute(request);
+    query.subscribeLive();
+    const refresh = query.refresh();
+    await vi.waitFor(() => expect(queryCalls).toBe(2));
+    onLive?.(envelope(request, 'live'));
+    await vi.waitFor(() => expect(query.state.rows[0]?.name).toBe('live'));
+    resolveRefresh(envelope(request, 'stale-refresh'));
+    await refresh;
+
+    expect(query.state.rows[0]?.name).toBe('live');
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('does not let a pending flight repopulate cache after dispose', async () => {
     let resolvePending!: (result: unknown) => void;
     let queryCalls = 0;
@@ -456,6 +534,71 @@ describe('remote query controller', () => {
     expect(query.state.stale).toBe(true);
     expect(query.state.error).toBeInstanceOf(TypeError);
     query.dispose();
+    await collection.cleanup();
+  });
+
+  it('does not let a pre-invalidation refresh restore a fresh cache entry', async () => {
+    let resolveRefresh!: (result: unknown) => void;
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        calls += 1;
+        if (calls === 1) return envelope(received, 'initial');
+        if (calls === 2) {
+          return await new Promise((resolve) => {
+            resolveRefresh = resolve;
+          });
+        }
+        return envelope(received, 'after-invalidation');
+      },
+    });
+
+    await query.execute(request);
+    const refresh = query.refresh();
+    await vi.waitFor(() => expect(calls).toBe(2));
+    query.invalidate();
+    resolveRefresh(envelope(request, 'stale-refresh'));
+    await refresh;
+
+    expect(query.state.rows[0]?.name).toBe('initial');
+    expect(query.state.stale).toBe(true);
+    await query.execute(request);
+    expect(calls).toBe(3);
+    expect(query.state.rows[0]?.name).toBe('after-invalidation');
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('aborts non-visible work when disposed', async () => {
+    let started = false;
+    let aborted = false;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (_received, options) => {
+        started = true;
+        return await new Promise<never>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            'abort',
+            () => {
+              aborted = true;
+              reject(options.signal?.reason);
+            },
+            { once: true },
+          );
+        });
+      },
+    });
+    const pending = query.execute(request, { mode: 'background' });
+    await vi.waitFor(() => expect(started).toBe(true));
+    query.dispose();
+
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(aborted).toBe(true);
     await collection.cleanup();
   });
 

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -485,6 +485,35 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('treats a transport custom error after abort as cancellation', async () => {
+    const caller = new AbortController();
+    let started = false;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (_received, options) => {
+        started = true;
+        return await new Promise<never>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            'abort',
+            () => reject(new Error('transport cancellation')),
+            { once: true },
+          );
+        });
+      },
+    });
+    const pending = query.execute(request, { signal: caller.signal });
+    await vi.waitFor(() => expect(started).toBe(true));
+    caller.abort();
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(query.state.error).toBeNull();
+    expect(query.state.loading).toBe(false);
+    expect(query.state.refreshing).toBe(false);
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('clears refreshing after the current refresh is cancelled', async () => {
     const caller = new AbortController();
     let calls = 0;

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -128,6 +128,45 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it("does not let an earlier caller's abort cancel its visible successor", async () => {
+    const callerA = new AbortController();
+    const calls: string[] = [];
+    let resolveB!: (result: unknown) => void;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received, options) => {
+        calls.push(received.requestId);
+        if (received.requestId === 'request-1') {
+          return await new Promise<never>((_resolve, reject) => {
+            options?.signal?.addEventListener(
+              'abort',
+              () => reject(options.signal?.reason),
+              { once: true },
+            );
+          });
+        }
+        return await new Promise((resolve) => {
+          resolveB = resolve;
+        });
+      },
+    });
+    const first = query
+      .execute(request, { signal: callerA.signal })
+      .catch(() => undefined);
+    await vi.waitFor(() => expect(calls).toEqual(['request-1']));
+    const second = query.execute({ ...request, requestId: 'request-2' });
+    await vi.waitFor(() => expect(calls).toEqual(['request-1', 'request-2']));
+    callerA.abort();
+    resolveB(envelope({ ...request, requestId: 'request-2' }, 'successor'));
+    await second;
+    await first;
+    expect(query.state.rows[0]?.name).toBe('successor');
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('keeps the forced successor in the in-flight map until it settles', async () => {
     const releases: Array<() => void> = [];
     let calls = 0;
@@ -226,6 +265,7 @@ describe('remote query controller', () => {
     await query.execute(request);
     const live = query.subscribeLive();
     const oldCallback = callbacks[0];
+    oldCallback?.(envelope(request, 'late-before-reconnect'));
     live?.reconnect();
     await vi.waitFor(() => expect(subscriptions).toBe(2));
     expect(queryCalls).toBe(2);

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -514,6 +514,35 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('normalizes an arbitrary caller abort reason', async () => {
+    const caller = new AbortController();
+    let started = false;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (_received, options) => {
+        started = true;
+        return await new Promise<never>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            'abort',
+            () => reject(options.signal?.reason),
+            { once: true },
+          );
+        });
+      },
+    });
+    const pending = query.execute(request, { signal: caller.signal });
+    await vi.waitFor(() => expect(started).toBe(true));
+    caller.abort('caller reason');
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    expect(query.state.error).toBeNull();
+    expect(query.state.loading).toBe(false);
+    expect(query.state.refreshing).toBe(false);
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('clears refreshing after the current refresh is cancelled', async () => {
     const caller = new AbortController();
     let calls = 0;

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -109,6 +109,30 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('does not apply a cancelled fresh-cache read', async () => {
+    const caller = new AbortController();
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => envelope(received, 'cached'),
+    });
+
+    await query.execute(request);
+    caller.abort();
+    await expect(
+      query.execute(
+        { ...request, requestId: 'request-2' },
+        { signal: caller.signal },
+      ),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+
+    expect(query.request?.requestId).toBe('request-1');
+    expect(query.state.result?.requestId).toBe('request-1');
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('rebinds an in-flight shared result to each caller request id', async () => {
     let resolveQuery!: (result: ReturnType<typeof envelope>) => void;
     let calls = 0;
@@ -700,6 +724,44 @@ describe('remote query controller', () => {
     await Promise.resolve();
 
     expect(query.state.rows[0]?.name).toBe('explicit');
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('does not surface an older invalid live update after a newer fetch succeeds', async () => {
+    let onResult: ((value: unknown) => void) | undefined;
+    let resolveInvalid!: (value: unknown) => void;
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        calls += 1;
+        return envelope(received, calls === 1 ? 'initial' : 'explicit');
+      },
+      subscribe: (_received, callback) => {
+        onResult = callback;
+        return { unsubscribe: () => undefined };
+      },
+    });
+    const invalidLive = new Promise<unknown>((resolve) => {
+      resolveInvalid = resolve;
+    });
+
+    await query.execute(request);
+    query.subscribeLive();
+    onResult?.(invalidLive);
+    await query.execute(
+      { ...request, requestId: 'request-2' },
+      { force: true },
+    );
+    resolveInvalid({ invalid: true });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(query.state.rows[0]?.name).toBe('explicit');
+    expect(query.state.error).toBeNull();
     query.dispose();
     await collection.cleanup();
   });

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -197,6 +197,40 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('keeps an older forced flight from overwriting a newer cached result', async () => {
+    const releases: Array<() => void> = [];
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        calls += 1;
+        const name = calls === 1 ? 'A' : 'B';
+        return await new Promise((resolve) => {
+          releases.push(() => resolve(envelope(received, name)));
+        });
+      },
+    });
+    const first = query.execute(request, { mode: 'background' });
+    await vi.waitFor(() => expect(calls).toBe(1));
+    const second = query.execute(request, {
+      mode: 'background',
+      force: true,
+    });
+    await vi.waitFor(() => expect(calls).toBe(2));
+    releases[1]?.();
+    await second;
+    releases[0]?.();
+    await first;
+
+    await query.execute(request);
+    expect(calls).toBe(2);
+    expect(query.state.rows[0]?.name).toBe('B');
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('prefetches into the keyed cache without changing visible state, then refreshes coherently', async () => {
     let value = 'prefetched';
     const collection = createSmrtCollection(definition, {

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -732,6 +732,70 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('keeps live updates after rapid visible query changes', async () => {
+    const subscriptions: Array<{
+      request: SmrtWebDataQueryRequest;
+      callback: (value: unknown) => void;
+    }> = [];
+    let calls = 0;
+    let unsubscribed = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received, options) => {
+        calls += 1;
+        if (calls === 2) {
+          return await new Promise<never>((_resolve, reject) => {
+            options?.signal?.addEventListener(
+              'abort',
+              () => reject(options.signal?.reason),
+              { once: true },
+            );
+          });
+        }
+        return envelope(received, calls === 1 ? 'initial' : 'latest');
+      },
+      subscribe: (received, callback) => {
+        subscriptions.push({ request: received, callback });
+        return {
+          unsubscribe: () => {
+            unsubscribed += 1;
+          },
+        };
+      },
+    });
+    const intermediateRequest = {
+      ...request,
+      requestId: 'request-2',
+      page: { kind: 'offset' as const, offset: 10, limit: 10 },
+    };
+    const latestRequest = {
+      ...request,
+      requestId: 'request-3',
+      page: { kind: 'offset' as const, offset: 20, limit: 10 },
+    };
+
+    await query.execute(request);
+    query.subscribeLive();
+    const intermediate = query
+      .execute(intermediateRequest)
+      .catch(() => undefined);
+    await vi.waitFor(() => expect(calls).toBe(2));
+    await query.execute(latestRequest);
+    await intermediate;
+
+    expect(unsubscribed).toBe(1);
+    expect(subscriptions).toHaveLength(2);
+    expect(subscriptions[1]?.request).toEqual(latestRequest);
+    subscriptions[1]?.callback(envelope(latestRequest, 'latest-live'));
+    await vi.waitFor(() =>
+      expect(query.state.rows[0]?.name).toBe('latest-live'),
+    );
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('does not let a delayed live update overtake a newer explicit fetch', async () => {
     let onResult: ((value: unknown) => void) | undefined;
     let resolveLive!: (result: ReturnType<typeof envelope>) => void;

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -109,6 +109,36 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('rebinds an in-flight shared result to each caller request id', async () => {
+    let resolveQuery!: (result: ReturnType<typeof envelope>) => void;
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        calls += 1;
+        return await new Promise<ReturnType<typeof envelope>>((resolve) => {
+          resolveQuery = resolve;
+          void received;
+        });
+      },
+    });
+
+    const first = query.execute(request, { mode: 'background' });
+    const second = query.execute(
+      { ...request, requestId: 'request-2' },
+      { mode: 'background' },
+    );
+    resolveQuery(envelope(request, 'shared'));
+
+    expect(calls).toBe(1);
+    await expect(first).resolves.toMatchObject({ requestId: 'request-1' });
+    await expect(second).resolves.toMatchObject({ requestId: 'request-2' });
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('releases visible refresh state when a background successor wins the cache', async () => {
     let resolveRefresh!: (result: ReturnType<typeof envelope>) => void;
     let calls = 0;

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -667,6 +667,43 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('does not let a delayed live update overtake a newer explicit fetch', async () => {
+    let onResult: ((value: unknown) => void) | undefined;
+    let resolveLive!: (result: ReturnType<typeof envelope>) => void;
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        calls += 1;
+        return envelope(received, calls === 1 ? 'initial' : 'explicit');
+      },
+      subscribe: (_received, callback) => {
+        onResult = callback;
+        return { unsubscribe: () => undefined };
+      },
+    });
+    const pendingLive = new Promise<ReturnType<typeof envelope>>((resolve) => {
+      resolveLive = resolve;
+    });
+
+    await query.execute(request);
+    query.subscribeLive();
+    onResult?.(pendingLive);
+    await query.execute(
+      { ...request, requestId: 'request-2' },
+      { force: true },
+    );
+    resolveLive(envelope(request, 'stale-live'));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(query.state.rows[0]?.name).toBe('explicit');
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('refetches before fallback reconnect, resubscribes, and ignores old callbacks', async () => {
     const callbacks: Array<(value: unknown) => void> = [];
     let queryCalls = 0;

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -522,6 +522,47 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('does not surface an obsolete live validation error on a newer request', async () => {
+    let onLive: ((value: unknown) => void) | undefined;
+    let resolveNew!: (result: ReturnType<typeof envelope>) => void;
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        calls += 1;
+        if (calls === 1) return envelope(received, 'initial');
+        return await new Promise<ReturnType<typeof envelope>>((resolve) => {
+          resolveNew = resolve;
+        });
+      },
+      subscribe: (_received, callback) => {
+        onLive = callback;
+        return { unsubscribe: () => undefined };
+      },
+    });
+    const nextRequest = {
+      ...request,
+      requestId: 'request-2',
+      page: { kind: 'offset' as const, offset: 10, limit: 10 },
+    };
+
+    await query.execute(request);
+    query.subscribeLive();
+    onLive?.({ invalid: true });
+    const newer = query.execute(nextRequest);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(query.state.error).toBeNull();
+    resolveNew(envelope(nextRequest, 'newer'));
+    await newer;
+    expect(query.state.rows[0]?.name).toBe('newer');
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('does not let a pending flight repopulate cache after dispose', async () => {
     let resolvePending!: (result: unknown) => void;
     let queryCalls = 0;

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -97,6 +97,67 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('starts a new same-key visible request after aborting its predecessor', async () => {
+    const calls: string[] = [];
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received, options) => {
+        calls.push(received.requestId);
+        if (calls.length === 1) {
+          return await new Promise<never>((_resolve, reject) => {
+            options?.signal?.addEventListener(
+              'abort',
+              () => reject(options.signal?.reason),
+              { once: true },
+            );
+          });
+        }
+        return envelope(received, 'replacement');
+      },
+    });
+    const predecessor = query.execute(request).catch(() => undefined);
+    await vi.waitFor(() => expect(calls).toHaveLength(1));
+    const successor = query.execute({ ...request, requestId: 'same-key-2' });
+    await successor;
+    await predecessor;
+    expect(calls).toEqual(['request-1', 'same-key-2']);
+    expect(query.state.rows[0]?.name).toBe('replacement');
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('keeps the forced successor in the in-flight map until it settles', async () => {
+    const releases: Array<() => void> = [];
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        calls += 1;
+        await new Promise<void>((resolve) => releases.push(resolve));
+        return envelope(received, `flight-${calls}`);
+      },
+    });
+    const predecessor = query.execute(request, { mode: 'background' });
+    await vi.waitFor(() => expect(calls).toBe(1));
+    const successor = query.execute(request, {
+      mode: 'background',
+      force: true,
+    });
+    await vi.waitFor(() => expect(calls).toBe(2));
+    releases[0]?.();
+    await predecessor;
+    const deduped = query.execute(request, { mode: 'background' });
+    expect(calls).toBe(2);
+    releases[1]?.();
+    await Promise.all([successor, deduped]);
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('prefetches into the keyed cache without changing visible state, then refreshes coherently', async () => {
     let value = 'prefetched';
     const collection = createSmrtCollection(definition, {
@@ -140,6 +201,71 @@ describe('remote query controller', () => {
     await vi.waitFor(() => expect(query.state.rows[0]?.name).toBe('live'));
     live?.unsubscribe();
     expect(unsubscribed).toBe(true);
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('refetches before fallback reconnect, resubscribes, and ignores old callbacks', async () => {
+    const callbacks: Array<(value: unknown) => void> = [];
+    let queryCalls = 0;
+    let subscriptions = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        queryCalls += 1;
+        return envelope(received, queryCalls === 1 ? 'initial' : 'resynced');
+      },
+      subscribe: (_received, callback) => {
+        subscriptions += 1;
+        callbacks.push(callback);
+        return { unsubscribe: () => undefined };
+      },
+    });
+    await query.execute(request);
+    const live = query.subscribeLive();
+    const oldCallback = callbacks[0];
+    live?.reconnect();
+    await vi.waitFor(() => expect(subscriptions).toBe(2));
+    expect(queryCalls).toBe(2);
+    oldCallback?.(envelope(request, 'late-old'));
+    await Promise.resolve();
+    expect(query.state.rows[0]?.name).toBe('initial');
+    callbacks[1]?.(envelope(request, 'reconnected'));
+    await vi.waitFor(() =>
+      expect(query.state.rows[0]?.name).toBe('reconnected'),
+    );
+    live?.unsubscribe();
+    callbacks[1]?.(envelope(request, 'late-unsubscribed'));
+    await Promise.resolve();
+    expect(query.state.rows[0]?.name).toBe('reconnected');
+    query.dispose();
+    callbacks[1]?.(envelope(request, 'late-disposed'));
+    await Promise.resolve();
+    expect(query.state.rows[0]?.name).toBe('reconnected');
+    await collection.cleanup();
+  });
+
+  it('marks invalidated data stale and retains rows when the next request is offline', async () => {
+    let offline = false;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        if (offline) throw new TypeError('offline');
+        return envelope(received, 'cached');
+      },
+    });
+    await query.execute(request);
+    query.invalidate();
+    expect(query.state.stale).toBe(true);
+    offline = true;
+    await expect(query.refresh()).rejects.toThrow('offline');
+    expect(query.state.rows[0]?.name).toBe('cached');
+    expect(query.state.stale).toBe(true);
+    expect(query.state.error).toBeInstanceOf(TypeError);
     query.dispose();
     await collection.cleanup();
   });

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -683,6 +683,59 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('rejects a fresh-cache read when its state listener disposes the query', async () => {
+    let calls = 0;
+    let disposeOnNextState = false;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        calls += 1;
+        return envelope(received, 'cached');
+      },
+    });
+    const unsubscribe = query.subscribe(() => {
+      if (disposeOnNextState) query.dispose();
+    });
+
+    await query.execute(request);
+    disposeOnNextState = true;
+    await expect(
+      query.execute({ ...request, requestId: 'request-2' }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+
+    expect(calls).toBe(1);
+    expect(query.request).toBeUndefined();
+    unsubscribe();
+    await collection.cleanup();
+  });
+
+  it('cleans up a subscription that disposes the query synchronously', async () => {
+    let unsubscribed = 0;
+    let query!: ReturnType<typeof createSmrtWebQuery<Row>>;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    query = createSmrtWebQuery(collection, {
+      query: async (received) => envelope(received, 'initial'),
+      subscribe: () => {
+        query.dispose();
+        return {
+          unsubscribe: () => {
+            unsubscribed += 1;
+          },
+        };
+      },
+    });
+
+    await query.execute(request);
+    expect(query.subscribeLive()).toBeUndefined();
+    expect(unsubscribed).toBe(1);
+    expect(query.request).toBeUndefined();
+    await collection.cleanup();
+  });
+
   it('prefetches into the keyed cache without changing visible state, then refreshes coherently', async () => {
     let value = 'prefetched';
     const collection = createSmrtCollection(definition, {
@@ -1043,7 +1096,7 @@ describe('remote query controller', () => {
     expect(queryCalls).toBe(2);
     oldCallback?.(envelope(request, 'late-old'));
     await Promise.resolve();
-    expect(query.state.rows[0]?.name).toBe('initial');
+    expect(query.state.rows[0]?.name).toBe('resynced');
     callbacks[1]?.(envelope(request, 'reconnected'));
     await vi.waitFor(() =>
       expect(query.state.rows[0]?.name).toBe('reconnected'),

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -736,6 +736,73 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('keeps a cached rebind successful when its automatic live bind fails', async () => {
+    const liveError = new Error('live transport unavailable');
+    let subscriptions = 0;
+    const alternate = {
+      ...request,
+      filter: {
+        kind: 'condition' as const,
+        field: 'name',
+        operator: 'eq' as const,
+        value: 'alternate',
+      },
+    };
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) =>
+        envelope(
+          received,
+          received.filter === alternate.filter ? 'alternate' : 'initial',
+        ),
+      subscribe: () => {
+        subscriptions += 1;
+        if (subscriptions > 1) throw liveError;
+        return { unsubscribe: () => undefined };
+      },
+    });
+
+    await query.execute(alternate, { mode: 'prefetch' });
+    await query.execute(request);
+    query.subscribeLive();
+    await expect(query.execute(alternate)).resolves.toMatchObject({
+      requestId: 'request-1',
+    });
+
+    expect(subscriptions).toBe(2);
+    expect(query.state.rows[0]?.name).toBe('alternate');
+    expect(query.state.error).toBe(liveError);
+    query.dispose();
+    await collection.cleanup();
+  });
+
+  it('reports a failed reconnect bind without an unhandled rejection', async () => {
+    const liveError = new Error('reconnect unavailable');
+    let failReconnect = false;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => envelope(received, 'refreshed'),
+      subscribe: () => {
+        if (failReconnect) throw liveError;
+        return { unsubscribe: () => undefined };
+      },
+    });
+
+    await query.execute(request);
+    const live = query.subscribeLive();
+    failReconnect = true;
+    live?.reconnect();
+
+    await vi.waitFor(() => expect(query.state.error).toBe(liveError));
+    expect(query.state.rows[0]?.name).toBe('refreshed');
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('prefetches into the keyed cache without changing visible state, then refreshes coherently', async () => {
     let value = 'prefetched';
     const collection = createSmrtCollection(definition, {

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -613,9 +613,14 @@ describe('remote query controller', () => {
     await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
     expect(query.state.rows[0]?.name).toBe('initial');
 
-    await query.execute(request, { mode: 'background' });
-    expect(queryCalls).toBe(3);
-    query.dispose();
+    await expect(query.execute(request)).rejects.toMatchObject({
+      name: 'AbortError',
+    });
+    await expect(
+      query.execute(request, { mode: 'background' }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(query.request).toBeUndefined();
+    expect(queryCalls).toBe(2);
     await collection.cleanup();
   });
 

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -231,6 +231,50 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('retains an older result when its forced successor aborts', async () => {
+    const caller = new AbortController();
+    let resolveA!: (result: unknown) => void;
+    let calls = 0;
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received, options) => {
+        calls += 1;
+        if (calls === 1) {
+          return await new Promise((resolve) => {
+            resolveA = resolve;
+          });
+        }
+        return await new Promise<never>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            'abort',
+            () => reject(options.signal?.reason),
+            { once: true },
+          );
+        });
+      },
+    });
+    const first = query.execute(request, { mode: 'background' });
+    await vi.waitFor(() => expect(calls).toBe(1));
+    const second = query.execute(request, {
+      mode: 'background',
+      force: true,
+      signal: caller.signal,
+    });
+    await vi.waitFor(() => expect(calls).toBe(2));
+    caller.abort();
+    await expect(second).rejects.toMatchObject({ name: 'AbortError' });
+    resolveA(envelope(request, 'A'));
+    await first;
+
+    await query.execute(request);
+    expect(calls).toBe(2);
+    expect(query.state.rows[0]?.name).toBe('A');
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('prefetches into the keyed cache without changing visible state, then refreshes coherently', async () => {
     let value = 'prefetched';
     const collection = createSmrtCollection(definition, {

--- a/packages/smrt-web/src/remote-query.test.ts
+++ b/packages/smrt-web/src/remote-query.test.ts
@@ -906,6 +906,92 @@ describe('remote query controller', () => {
     await collection.cleanup();
   });
 
+  it('restores the target stale cache snapshot while refreshing it', async () => {
+    const refreshError = new Error('refresh unavailable');
+    let failRefresh = false;
+    const first = {
+      ...request,
+      filter: {
+        kind: 'condition' as const,
+        field: 'name',
+        operator: 'eq' as const,
+        value: 'first',
+      },
+    };
+    const second = {
+      ...request,
+      requestId: 'request-2',
+      filter: {
+        kind: 'condition' as const,
+        field: 'name',
+        operator: 'eq' as const,
+        value: 'second',
+      },
+    };
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(
+      collection,
+      {
+        query: async (received) => {
+          if (failRefresh) throw refreshError;
+          return envelope(
+            received,
+            received.filter === first.filter ? 'first' : 'second',
+          );
+        },
+      },
+      { staleTimeMs: 0 },
+    );
+
+    await query.execute(first);
+    await query.execute(second);
+    failRefresh = true;
+    const refresh = query.execute(first);
+
+    expect(query.state.rows[0]?.name).toBe('first');
+    expect(query.state.result?.requestId).toBe('request-1');
+    expect(query.state.refreshing).toBe(true);
+    await expect(refresh).rejects.toBe(refreshError);
+    expect(query.state.rows[0]?.name).toBe('first');
+    await collection.cleanup();
+  });
+
+  it('reconnects a same-key live query with the latest request id', async () => {
+    const subscribed: SmrtWebDataQueryRequest[] = [];
+    const queried: SmrtWebDataQueryRequest[] = [];
+    const collection = createSmrtCollection(definition, {
+      fetchers: { list: async () => [], create: async () => ({}) },
+    });
+    const query = createSmrtWebQuery(collection, {
+      query: async (received) => {
+        queried.push(received);
+        return envelope(received, 'resynced');
+      },
+      subscribe: (received) => {
+        subscribed.push(received);
+        return { unsubscribe: () => undefined };
+      },
+    });
+    const latestRequest = { ...request, requestId: 'request-2' };
+
+    await query.execute(request);
+    const live = query.subscribeLive();
+    await query.execute(latestRequest);
+    live?.reconnect();
+
+    await vi.waitFor(() => expect(subscribed).toHaveLength(2));
+    expect(queried.map(({ requestId }) => requestId)).toEqual([
+      'request-1',
+      'request-2',
+    ]);
+    expect(subscribed[1]?.requestId).toBe('request-2');
+    expect(query.state.result?.requestId).toBe('request-2');
+    query.dispose();
+    await collection.cleanup();
+  });
+
   it('replaces an active live subscription for a different visible query', async () => {
     const subscriptions: Array<{
       request: SmrtWebDataQueryRequest;

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -1,0 +1,354 @@
+import {
+  executeSmrtWebDataQuery,
+  type SmrtWebDataQueryRequest,
+  type SmrtWebDataQueryResult,
+  type SmrtWebDataQueryTransport,
+} from './data-query.js';
+import type { SmrtWebCollection } from './index.js';
+
+/** How a query run is allowed to affect the visible query state. */
+export type SmrtWebQueryMode = 'visible' | 'background' | 'prefetch' | 'silent';
+
+export interface SmrtWebQueryRunOptions {
+  mode?: SmrtWebQueryMode;
+  signal?: AbortSignal;
+  /** Cancel this run after the given number of milliseconds. */
+  deadlineMs?: number;
+  /** Bypass the keyed cache and execute a fresh request (used by refresh). */
+  force?: boolean;
+}
+
+export interface SmrtWebQueryPage {
+  kind: 'offset' | 'cursor';
+  limit: number;
+  offset?: number;
+  nextCursor?: string;
+  hasMore: boolean;
+}
+
+export interface SmrtWebQueryState<TData extends object = object> {
+  readonly rows: ReadonlyArray<TData>;
+  readonly page: SmrtWebQueryPage | undefined;
+  readonly total: SmrtWebDataQueryResult['total'] | undefined;
+  readonly loading: boolean;
+  readonly refreshing: boolean;
+  readonly stale: boolean;
+  readonly error: unknown;
+  readonly lastUpdated: number | undefined;
+  readonly result: SmrtWebDataQueryResult | undefined;
+}
+
+export interface SmrtWebQueryLiveSubscription {
+  unsubscribe(): void;
+  reconnect(): void;
+}
+
+export interface SmrtWebQueryTransport extends SmrtWebDataQueryTransport {
+  /** Subscribe to changes for this exact query, not the entire collection. */
+  subscribe?(
+    request: SmrtWebDataQueryRequest,
+    onResult: (result: unknown) => void,
+    options?: { signal?: AbortSignal },
+  ): SmrtWebQueryLiveSubscription | { unsubscribe(): void };
+}
+
+export interface SmrtWebQuery<TData extends object = object> {
+  readonly state: SmrtWebQueryState<TData>;
+  readonly request: SmrtWebDataQueryRequest | undefined;
+  execute(
+    request: SmrtWebDataQueryRequest,
+    options?: SmrtWebQueryRunOptions,
+  ): Promise<SmrtWebDataQueryResult>;
+  refresh(
+    options?: Omit<SmrtWebQueryRunOptions, 'mode' | 'force'>,
+  ): Promise<SmrtWebDataQueryResult | undefined>;
+  retry(): Promise<SmrtWebDataQueryResult | undefined>;
+  subscribe(listener: (state: SmrtWebQueryState<TData>) => void): () => void;
+  subscribeLive(): SmrtWebQueryLiveSubscription | undefined;
+  invalidate(): void;
+  dispose(): void;
+}
+
+interface CacheEntry {
+  result: SmrtWebDataQueryResult;
+  updatedAt: number;
+}
+
+function keyFor(request: SmrtWebDataQueryRequest): string {
+  // requestId is correlation metadata, not query identity. Removing it allows
+  // refreshes and independently-created equivalent requests to share a result.
+  const { requestId: _requestId, ...semantic } = request;
+  return JSON.stringify(semantic);
+}
+
+function abortError(): DOMException | Error {
+  if (typeof DOMException !== 'undefined')
+    return new DOMException('The operation was aborted', 'AbortError');
+  const error = new Error('The operation was aborted');
+  error.name = 'AbortError';
+  return error;
+}
+
+function isAbort(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === 'object' &&
+    (error as { name?: unknown }).name === 'AbortError'
+  );
+}
+
+function pageOf(result: SmrtWebDataQueryResult): SmrtWebQueryPage | undefined {
+  if (!result.page) return undefined;
+  return result.page.kind === 'offset'
+    ? { ...result.page }
+    : { ...result.page };
+}
+
+/**
+ * Create a query controller over one SMRT collection. Query rows stay in a
+ * separate keyed cache; the collection's full list is never loaded.
+ */
+export function createSmrtWebQuery<TData extends object>(
+  _collection: SmrtWebCollection<TData>,
+  transport: SmrtWebQueryTransport,
+  options: { staleTimeMs?: number } = {},
+): SmrtWebQuery<TData> {
+  const staleTimeMs = options.staleTimeMs ?? 30_000;
+  const cache = new Map<string, CacheEntry>();
+  const inFlight = new Map<string, Promise<SmrtWebDataQueryResult>>();
+  const listeners = new Set<(state: SmrtWebQueryState<TData>) => void>();
+  let request: SmrtWebDataQueryRequest | undefined;
+  let visibleController: AbortController | undefined;
+  let generation = 0;
+  let live: SmrtWebQueryLiveSubscription | undefined;
+  let state: SmrtWebQueryState<TData> = {
+    rows: [],
+    page: undefined,
+    total: undefined,
+    loading: false,
+    refreshing: false,
+    stale: false,
+    error: null,
+    lastUpdated: undefined,
+    result: undefined,
+  };
+
+  const publish = (next: SmrtWebQueryState<TData>): void => {
+    state = next;
+    for (const listener of listeners) listener(state);
+  };
+  const cached = (key: string): CacheEntry | undefined => cache.get(key);
+  const apply = (
+    result: SmrtWebDataQueryResult,
+    candidate: SmrtWebDataQueryRequest,
+    updatedAt = Date.now(),
+  ): void => {
+    const entry = { result, updatedAt };
+    cache.set(keyFor(candidate), entry);
+    publish({
+      rows: result.rows as TData[],
+      page: pageOf(result),
+      total: result.total,
+      loading: false,
+      refreshing: false,
+      stale: result.freshness.state === 'stale',
+      error: null,
+      lastUpdated: updatedAt,
+      result,
+    });
+  };
+  const runTransport = async (
+    candidate: SmrtWebDataQueryRequest,
+    runOptions: SmrtWebQueryRunOptions,
+  ): Promise<SmrtWebDataQueryResult> => {
+    const controller = new AbortController();
+    const cleanups: Array<() => void> = [];
+    const abortFrom = (signal: AbortSignal | undefined): void => {
+      if (!signal) return;
+      if (signal.aborted) controller.abort(signal.reason);
+      else {
+        const abort = () => controller.abort(signal.reason);
+        signal.addEventListener('abort', abort, { once: true });
+        cleanups.push(() => signal.removeEventListener('abort', abort));
+      }
+    };
+    abortFrom(runOptions.signal);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    if (runOptions.deadlineMs !== undefined) {
+      if (runOptions.deadlineMs <= 0) controller.abort(abortError());
+      else
+        timer = setTimeout(
+          () => controller.abort(abortError()),
+          runOptions.deadlineMs,
+        );
+    }
+    try {
+      return await executeSmrtWebDataQuery(transport, candidate, {
+        signal: controller.signal,
+      });
+    } finally {
+      if (timer) clearTimeout(timer);
+      for (const cleanup of cleanups) cleanup();
+    }
+  };
+  const execute = async (
+    candidate: SmrtWebDataQueryRequest,
+    runOptions: SmrtWebQueryRunOptions = {},
+  ): Promise<SmrtWebDataQueryResult> => {
+    const mode = runOptions.mode ?? 'visible';
+    const key = keyFor(candidate);
+    const entry = cached(key);
+    const fresh =
+      entry !== undefined && Date.now() - entry.updatedAt < staleTimeMs;
+    if (mode !== 'visible' && !runOptions.force && fresh) return entry.result;
+    if (mode === 'visible' && !runOptions.force && fresh) {
+      generation += 1;
+      visibleController?.abort(abortError());
+      visibleController = undefined;
+      request = candidate;
+      apply(entry.result, candidate, entry.updatedAt);
+      return entry.result;
+    }
+    if (mode === 'visible') {
+      generation += 1;
+      visibleController?.abort(abortError());
+      visibleController = new AbortController();
+      request = candidate;
+      const current = generation;
+      const signal = runOptions.signal;
+      if (signal?.aborted) visibleController.abort(signal.reason);
+      else if (signal)
+        signal.addEventListener(
+          'abort',
+          () => visibleController?.abort(signal.reason),
+          { once: true },
+        );
+      publish({
+        ...state,
+        loading: entry === undefined,
+        refreshing: entry !== undefined,
+        stale: entry !== undefined,
+        error: null,
+      });
+      runOptions = { ...runOptions, signal: visibleController.signal };
+      try {
+        const result = await runShared(candidate, key, runOptions);
+        if (current === generation) apply(result, candidate);
+        return result;
+      } catch (error) {
+        if (current === generation && !isAbort(error)) {
+          publish({
+            ...state,
+            loading: false,
+            refreshing: false,
+            stale: entry !== undefined,
+            error,
+          });
+        }
+        throw error;
+      }
+    }
+    return runShared(candidate, key, runOptions);
+  };
+  const runShared = async (
+    candidate: SmrtWebDataQueryRequest,
+    key: string,
+    runOptions: SmrtWebQueryRunOptions,
+  ): Promise<SmrtWebDataQueryResult> => {
+    if (!runOptions.force) {
+      const running = inFlight.get(key);
+      if (running) return running;
+    }
+    const running = runTransport(candidate, runOptions)
+      .then((result) => {
+        cache.set(key, { result, updatedAt: Date.now() });
+        return result;
+      })
+      .finally(() => inFlight.delete(key));
+    inFlight.set(key, running);
+    return running;
+  };
+  const refresh = (
+    refreshOptions: Omit<SmrtWebQueryRunOptions, 'mode' | 'force'> = {},
+  ) => {
+    if (!request) return Promise.resolve(undefined);
+    return execute(request, {
+      ...refreshOptions,
+      mode: 'visible',
+      force: true,
+    });
+  };
+  const subscribeLive = (): SmrtWebQueryLiveSubscription | undefined => {
+    if (!request || !transport.subscribe) return undefined;
+    live?.unsubscribe();
+    const candidate = request;
+    const controller = new AbortController();
+    const subscription = transport.subscribe(
+      candidate,
+      (raw) => {
+        void (async () => {
+          const result = await executeSmrtWebDataQuery(
+            { query: async () => raw },
+            candidate,
+          );
+          if (request && keyFor(request) === keyFor(candidate))
+            apply(result, candidate);
+        })().catch((error) => {
+          if (!isAbort(error)) publish({ ...state, error });
+        });
+      },
+      { signal: controller.signal },
+    );
+    const reconnect =
+      'reconnect' in subscription &&
+      typeof subscription.reconnect === 'function'
+        ? () => (subscription as SmrtWebQueryLiveSubscription).reconnect()
+        : () => {
+            controller.abort();
+            void execute(candidate, { mode: 'background', force: true });
+          };
+    live = {
+      unsubscribe: () => {
+        controller.abort();
+        subscription.unsubscribe();
+      },
+      reconnect,
+    };
+    return live;
+  };
+  return {
+    get state() {
+      return state;
+    },
+    get request() {
+      return request;
+    },
+    execute,
+    refresh,
+    retry: () => refresh(),
+    subscribe(listener) {
+      listeners.add(listener);
+      listener(state);
+      return () => listeners.delete(listener);
+    },
+    subscribeLive,
+    invalidate() {
+      if (!request) return;
+      cache.delete(keyFor(request));
+      publish({ ...state, stale: true });
+    },
+    dispose() {
+      generation += 1;
+      visibleController?.abort(abortError());
+      live?.unsubscribe();
+      listeners.clear();
+      cache.clear();
+      inFlight.clear();
+    },
+  };
+}
+
+// Naming aliases keep the capability discoverable for consumers that call the
+// feature a data query or a remote query; all aliases share the same controller.
+export const createSmrtDataQuery = createSmrtWebQuery;
+export const createSmrtQuery = createSmrtWebQuery;

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -116,6 +116,8 @@ export function createSmrtWebQuery<TData extends object>(
   const staleTimeMs = options.staleTimeMs ?? 30_000;
   const cache = new Map<string, CacheEntry>();
   const inFlight = new Map<string, Promise<SmrtWebDataQueryResult>>();
+  const latestSuccessfulFlight = new Map<string, number>();
+  let flightSequence = 0;
   const listeners = new Set<(state: SmrtWebQueryState<TData>) => void>();
   let request: SmrtWebDataQueryRequest | undefined;
   let visibleController: AbortController | undefined;
@@ -286,10 +288,13 @@ export function createSmrtWebQuery<TData extends object>(
       const running = inFlight.get(key);
       if (running) return running;
     }
+    const flight = ++flightSequence;
     const running = runTransport(candidate, runOptions).then((result) => {
-      // A forced successor can replace this flight before the predecessor
-      // settles. Only the current owner may publish to the keyed cache.
-      if (inFlight.get(key) === running) {
+      // A failed or aborted successor must not suppress an older valid result,
+      // but a successful successor must win over any later predecessor.
+      const latest = latestSuccessfulFlight.get(key);
+      if (latest === undefined || flight > latest) {
+        latestSuccessfulFlight.set(key, flight);
         cache.set(key, { result, updatedAt: Date.now() });
       }
       return result;

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -153,6 +153,7 @@ export function createSmrtWebQuery<TData extends object>(
   const runControllers = new Set<AbortController>();
   let generation = 0;
   let live: SmrtWebQueryLiveSubscription | undefined;
+  let liveRequested = false;
   let liveGeneration = 0;
   let disposed = false;
   let state: SmrtWebQueryState<TData> = {
@@ -247,11 +248,13 @@ export function createSmrtWebQuery<TData extends object>(
       throw abortError();
     // A live connection is scoped to the complete semantic query, not merely
     // the controller. Preserve it for a request-id rebinding, but replace it
-    // when visible state moves to a different page, filter, or sort.
-    const previousLive =
-      mode === 'visible' && request && live && keyFor(request) !== key
-        ? live
-        : undefined;
+    // when visible state moves to a different page, filter, or sort. Remember
+    // that live updates were requested while an earlier replacement is still
+    // in flight, so rapid visible changes cannot lose the subscription.
+    const shouldRebindLive =
+      mode === 'visible' &&
+      liveRequested &&
+      (!live || (request !== undefined && keyFor(request) !== key));
     const entry = cached(key);
     const fresh =
       entry !== undefined && Date.now() - entry.updatedAt < staleTimeMs;
@@ -262,10 +265,13 @@ export function createSmrtWebQuery<TData extends object>(
       visibleController?.abort(abortError());
       visibleController = undefined;
       request = candidate;
-      previousLive?.unsubscribe();
+      if (shouldRebindLive) {
+        live?.unsubscribe();
+        liveRequested = true;
+      }
       const result = rebindRequestId(entry.result, candidate);
       apply(result, candidate, entry.updatedAt);
-      if (previousLive && !live) subscribeLive();
+      if (shouldRebindLive && !live) subscribeLive();
       return result;
     }
     if (mode === 'visible') {
@@ -274,7 +280,10 @@ export function createSmrtWebQuery<TData extends object>(
       const invocationController = new AbortController();
       visibleController = invocationController;
       request = candidate;
-      previousLive?.unsubscribe();
+      if (shouldRebindLive) {
+        live?.unsubscribe();
+        liveRequested = true;
+      }
       const current = generation;
       const signal = runOptions.signal;
       let removeCallerAbort: (() => void) | undefined;
@@ -308,7 +317,7 @@ export function createSmrtWebQuery<TData extends object>(
         if (current === generation) {
           if (cached(key)?.result === result) apply(result, candidate);
           else publish({ ...state, loading: false, refreshing: false });
-          if (previousLive && !live) subscribeLive();
+          if (shouldRebindLive && !live) subscribeLive();
         }
         return result;
       } catch (error) {
@@ -510,7 +519,10 @@ export function createSmrtWebQuery<TData extends object>(
       liveGeneration += 1;
       controller?.abort();
       subscription.unsubscribe();
-      if (live === handle) live = undefined;
+      if (live === handle) {
+        live = undefined;
+        liveRequested = false;
+      }
     };
     const reconnect = (): void => {
       if (!active || disposed || currentGeneration !== liveGeneration) return;
@@ -537,6 +549,7 @@ export function createSmrtWebQuery<TData extends object>(
     handle = { unsubscribe, reconnect };
     connect();
     live = handle;
+    liveRequested = true;
     return handle;
   };
   return {
@@ -572,6 +585,7 @@ export function createSmrtWebQuery<TData extends object>(
       for (const controller of runControllers) controller.abort(abortError());
       live?.unsubscribe();
       live = undefined;
+      liveRequested = false;
       request = undefined;
       listeners.clear();
       cache.clear();

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -305,10 +305,14 @@ export function createSmrtWebQuery<TData extends object>(
       };
       try {
         const result = await runShared(candidate, key, runOptions);
-        // A query-scoped live update may have won while this transport was in
-        // flight. Only apply the result when it is still the cache's winner.
-        if (current === generation && cached(key)?.result === result)
-          apply(result, candidate);
+        // A query-scoped live update or background successor may have won
+        // while this transport was in flight. Do not let the older visible
+        // result overwrite it, but always release this invocation's busy
+        // state once it has settled.
+        if (current === generation) {
+          if (cached(key)?.result === result) apply(result, candidate);
+          else publish({ ...state, loading: false, refreshing: false });
+        }
         return result;
       } catch (error) {
         if (current === generation) {

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -121,6 +121,8 @@ export function createSmrtWebQuery<TData extends object>(
   let visibleController: AbortController | undefined;
   let generation = 0;
   let live: SmrtWebQueryLiveSubscription | undefined;
+  let liveGeneration = 0;
+  let disposed = false;
   let state: SmrtWebQueryState<TData> = {
     rows: [],
     page: undefined,
@@ -230,7 +232,13 @@ export function createSmrtWebQuery<TData extends object>(
         stale: entry !== undefined,
         error: null,
       });
-      runOptions = { ...runOptions, signal: visibleController.signal };
+      // A visible run is a successor boundary: it must never adopt an older
+      // same-key shared promise whose signal was just aborted above.
+      runOptions = {
+        ...runOptions,
+        signal: visibleController.signal,
+        force: true,
+      };
       try {
         const result = await runShared(candidate, key, runOptions);
         if (current === generation) apply(result, candidate);
@@ -259,13 +267,22 @@ export function createSmrtWebQuery<TData extends object>(
       const running = inFlight.get(key);
       if (running) return running;
     }
-    const running = runTransport(candidate, runOptions)
-      .then((result) => {
-        cache.set(key, { result, updatedAt: Date.now() });
-        return result;
-      })
-      .finally(() => inFlight.delete(key));
+    const running = runTransport(candidate, runOptions).then((result) => {
+      cache.set(key, { result, updatedAt: Date.now() });
+      return result;
+    });
     inFlight.set(key, running);
+    // A forced successor may replace this map entry while the predecessor is
+    // still settling. Only the promise that currently owns the key may delete
+    // it, otherwise a third caller can miss the active successor flight.
+    void running.then(
+      () => {
+        if (inFlight.get(key) === running) inFlight.delete(key);
+      },
+      () => {
+        if (inFlight.get(key) === running) inFlight.delete(key);
+      },
+    );
     return running;
   };
   const refresh = (
@@ -279,42 +296,85 @@ export function createSmrtWebQuery<TData extends object>(
     });
   };
   const subscribeLive = (): SmrtWebQueryLiveSubscription | undefined => {
-    if (!request || !transport.subscribe) return undefined;
+    if (disposed || !request || !transport.subscribe) return undefined;
     live?.unsubscribe();
     const candidate = request;
-    const controller = new AbortController();
-    const subscription = transport.subscribe(
-      candidate,
-      (raw) => {
-        void (async () => {
-          const result = await executeSmrtWebDataQuery(
-            { query: async () => raw },
-            candidate,
-          );
-          if (request && keyFor(request) === keyFor(candidate))
-            apply(result, candidate);
-        })().catch((error) => {
-          if (!isAbort(error)) publish({ ...state, error });
-        });
-      },
-      { signal: controller.signal },
-    );
-    const reconnect =
-      'reconnect' in subscription &&
-      typeof subscription.reconnect === 'function'
-        ? () => (subscription as SmrtWebQueryLiveSubscription).reconnect()
-        : () => {
-            controller.abort();
-            void execute(candidate, { mode: 'background', force: true });
-          };
-    live = {
-      unsubscribe: () => {
-        controller.abort();
-        subscription.unsubscribe();
-      },
-      reconnect,
+    const currentGeneration = ++liveGeneration;
+    let connectionGeneration = 0;
+    let controller: AbortController | undefined;
+    let subscription: SmrtWebQueryLiveSubscription | { unsubscribe(): void };
+    let active = true;
+    let handle: SmrtWebQueryLiveSubscription;
+    const connect = (): void => {
+      if (!active || disposed || currentGeneration !== liveGeneration) return;
+      controller = new AbortController();
+      const connection = ++connectionGeneration;
+      const subscribe = transport.subscribe;
+      if (!subscribe) return;
+      subscription = subscribe(
+        candidate,
+        (raw) => {
+          if (
+            !active ||
+            disposed ||
+            currentGeneration !== liveGeneration ||
+            connection !== connectionGeneration ||
+            controller?.signal.aborted
+          )
+            return;
+          void (async () => {
+            const result = await executeSmrtWebDataQuery(
+              { query: async () => raw },
+              candidate,
+            );
+            if (
+              active &&
+              !disposed &&
+              currentGeneration === liveGeneration &&
+              connection === connectionGeneration &&
+              request &&
+              keyFor(request) === keyFor(candidate)
+            )
+              apply(result, candidate);
+          })().catch((error) => {
+            if (
+              !isAbort(error) &&
+              active &&
+              !disposed &&
+              currentGeneration === liveGeneration &&
+              connection === connectionGeneration
+            )
+              publish({ ...state, error });
+          });
+        },
+        { signal: controller.signal },
+      );
     };
-    return live;
+    const unsubscribe = (): void => {
+      if (!active) return;
+      active = false;
+      liveGeneration += 1;
+      controller?.abort();
+      subscription.unsubscribe();
+      if (live === handle) live = undefined;
+    };
+    const reconnect = (): void => {
+      if (!active || disposed || currentGeneration !== liveGeneration) return;
+      controller?.abort();
+      subscription.unsubscribe();
+      // Refresh the exact page first, then replace the old subscription. This
+      // avoids reconnecting against a stale cursor or cached snapshot.
+      void execute(candidate, { mode: 'background', force: true })
+        .catch(() => undefined)
+        .finally(() => {
+          if (active && !disposed && currentGeneration === liveGeneration)
+            connect();
+        });
+    };
+    handle = { unsubscribe, reconnect };
+    connect();
+    live = handle;
+    return handle;
   };
   return {
     get state() {
@@ -334,21 +394,22 @@ export function createSmrtWebQuery<TData extends object>(
     subscribeLive,
     invalidate() {
       if (!request) return;
-      cache.delete(keyFor(request));
+      const key = keyFor(request);
+      const entry = cache.get(key);
+      if (entry) cache.set(key, { ...entry, updatedAt: 0 });
       publish({ ...state, stale: true });
     },
     dispose() {
+      disposed = true;
       generation += 1;
+      liveGeneration += 1;
       visibleController?.abort(abortError());
       live?.unsubscribe();
+      live = undefined;
+      request = undefined;
       listeners.clear();
       cache.clear();
       inFlight.clear();
     },
   };
 }
-
-// Naming aliases keep the capability discoverable for consumers that call the
-// feature a data query or a remote query; all aliases share the same controller.
-export const createSmrtDataQuery = createSmrtWebQuery;
-export const createSmrtQuery = createSmrtWebQuery;

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -214,17 +214,19 @@ export function createSmrtWebQuery<TData extends object>(
     if (mode === 'visible') {
       generation += 1;
       visibleController?.abort(abortError());
-      visibleController = new AbortController();
+      const invocationController = new AbortController();
+      visibleController = invocationController;
       request = candidate;
       const current = generation;
       const signal = runOptions.signal;
-      if (signal?.aborted) visibleController.abort(signal.reason);
-      else if (signal)
-        signal.addEventListener(
-          'abort',
-          () => visibleController?.abort(signal.reason),
-          { once: true },
-        );
+      let removeCallerAbort: (() => void) | undefined;
+      if (signal?.aborted) invocationController.abort(signal.reason);
+      else if (signal) {
+        const abortCaller = () => invocationController.abort(signal.reason);
+        signal.addEventListener('abort', abortCaller, { once: true });
+        removeCallerAbort = () =>
+          signal.removeEventListener('abort', abortCaller);
+      }
       publish({
         ...state,
         loading: entry === undefined,
@@ -236,7 +238,7 @@ export function createSmrtWebQuery<TData extends object>(
       // same-key shared promise whose signal was just aborted above.
       runOptions = {
         ...runOptions,
-        signal: visibleController.signal,
+        signal: invocationController.signal,
         force: true,
       };
       try {
@@ -254,6 +256,10 @@ export function createSmrtWebQuery<TData extends object>(
           });
         }
         throw error;
+      } finally {
+        removeCallerAbort?.();
+        if (visibleController === invocationController)
+          visibleController = undefined;
       }
     }
     return runShared(candidate, key, runOptions);
@@ -360,6 +366,10 @@ export function createSmrtWebQuery<TData extends object>(
     };
     const reconnect = (): void => {
       if (!active || disposed || currentGeneration !== liveGeneration) return;
+      // Invalidate callbacks that already entered envelope validation before
+      // aborting this connection; the replacement is installed only after the
+      // background refetch settles.
+      connectionGeneration += 1;
       controller?.abort();
       subscription.unsubscribe();
       // Refresh the exact page first, then replace the old subscription. This

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -385,6 +385,7 @@ export function createSmrtWebQuery<TData extends object>(
     const running = runTransport(candidate, controller).then((result) => {
       // A failed or aborted successor must not suppress an older valid result,
       // but a successful successor must win over any later predecessor.
+      if (controller.signal.aborted) throw abortError();
       cacheSuccess(key, result, flight);
       return result;
     });
@@ -467,7 +468,9 @@ export function createSmrtWebQuery<TData extends object>(
               active &&
               !disposed &&
               currentGeneration === liveGeneration &&
-              connection === connectionGeneration
+              connection === connectionGeneration &&
+              request &&
+              keyFor(request) === keyFor(candidate)
             )
               publish({ ...state, error });
           });

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -81,6 +81,15 @@ interface SharedFlight {
   settled: boolean;
 }
 
+interface LiveIntent {
+  active: boolean;
+}
+
+interface ManagedLiveSubscription extends SmrtWebQueryLiveSubscription {
+  readonly intent: LiveIntent;
+  disconnect(): void;
+}
+
 function canonicalize(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(canonicalize);
   if (value && typeof value === 'object') {
@@ -152,8 +161,8 @@ export function createSmrtWebQuery<TData extends object>(
   let visibleController: AbortController | undefined;
   const runControllers = new Set<AbortController>();
   let generation = 0;
-  let live: SmrtWebQueryLiveSubscription | undefined;
-  let liveRequested = false;
+  let live: ManagedLiveSubscription | undefined;
+  let liveIntent: LiveIntent | undefined;
   let liveGeneration = 0;
   let disposed = false;
   let state: SmrtWebQueryState<TData> = {
@@ -247,14 +256,14 @@ export function createSmrtWebQuery<TData extends object>(
     if (runOptions.signal?.aborted || (runOptions.deadlineMs ?? 1) <= 0)
       throw abortError();
     // A live connection is scoped to the complete semantic query, not merely
-    // the controller. Preserve it for a request-id rebinding, but replace it
-    // when visible state moves to a different page, filter, or sort. Remember
-    // that live updates were requested while an earlier replacement is still
-    // in flight, so rapid visible changes cannot lose the subscription.
+    // the controller. Preserve its caller-owned intent through a replacement
+    // so rapid visible changes cannot lose it, while a caller can still cancel
+    // that intent through the original returned subscription handle.
     const shouldRebindLive =
       mode === 'visible' &&
-      liveRequested &&
+      liveIntent?.active &&
       (!live || (request !== undefined && keyFor(request) !== key));
+    const rebindIntent = shouldRebindLive ? liveIntent : undefined;
     const entry = cached(key);
     const fresh =
       entry !== undefined && Date.now() - entry.updatedAt < staleTimeMs;
@@ -265,13 +274,10 @@ export function createSmrtWebQuery<TData extends object>(
       visibleController?.abort(abortError());
       visibleController = undefined;
       request = candidate;
-      if (shouldRebindLive) {
-        live?.unsubscribe();
-        liveRequested = true;
-      }
+      if (rebindIntent) live?.disconnect();
       const result = rebindRequestId(entry.result, candidate);
       apply(result, candidate, entry.updatedAt);
-      if (shouldRebindLive && !live) subscribeLive();
+      if (rebindIntent?.active && !live) startLive(rebindIntent);
       return result;
     }
     if (mode === 'visible') {
@@ -280,10 +286,7 @@ export function createSmrtWebQuery<TData extends object>(
       const invocationController = new AbortController();
       visibleController = invocationController;
       request = candidate;
-      if (shouldRebindLive) {
-        live?.unsubscribe();
-        liveRequested = true;
-      }
+      if (rebindIntent) live?.disconnect();
       const current = generation;
       const signal = runOptions.signal;
       let removeCallerAbort: (() => void) | undefined;
@@ -317,7 +320,7 @@ export function createSmrtWebQuery<TData extends object>(
         if (current === generation) {
           if (cached(key)?.result === result) apply(result, candidate);
           else publish({ ...state, loading: false, refreshing: false });
-          if (shouldRebindLive && !live) subscribeLive();
+          if (rebindIntent?.active && !live) startLive(rebindIntent);
         }
         return result;
       } catch (error) {
@@ -443,114 +446,127 @@ export function createSmrtWebQuery<TData extends object>(
       force: true,
     });
   };
-  const subscribeLive = (): SmrtWebQueryLiveSubscription | undefined => {
-    if (disposed || !request || !transport.subscribe) return undefined;
-    live?.unsubscribe();
+  const startLive = (
+    intent: LiveIntent,
+  ): ManagedLiveSubscription | undefined => {
+    if (disposed || !intent.active || !request || !transport.subscribe)
+      return undefined;
     const candidate = request;
     const currentGeneration = ++liveGeneration;
-    let connectionGeneration = 0;
-    let controller: AbortController | undefined;
+    const controller = new AbortController();
+    let connected = true;
     let subscription: SmrtWebQueryLiveSubscription | { unsubscribe(): void };
-    let active = true;
-    let handle: SmrtWebQueryLiveSubscription;
-    const connect = (): void => {
-      if (!active || disposed || currentGeneration !== liveGeneration) return;
-      controller = new AbortController();
-      const connection = ++connectionGeneration;
-      const subscribe = transport.subscribe;
-      if (!subscribe) return;
-      subscription = subscribe(
-        candidate,
-        (raw) => {
-          if (
-            !active ||
-            disposed ||
-            currentGeneration !== liveGeneration ||
-            connection !== connectionGeneration ||
-            controller?.signal.aborted
-          )
-            return;
-          // Claim ordering when the push arrives, before envelope validation
-          // yields. A later explicit fetch must remain newer even if this
-          // callback resumes after it.
-          const liveFlight = ++flightSequence;
-          void (async () => {
-            const result = await executeSmrtWebDataQuery(
-              { query: async () => raw },
-              candidate,
-            );
-            if (
-              active &&
-              !disposed &&
-              currentGeneration === liveGeneration &&
-              connection === connectionGeneration &&
-              request &&
-              keyFor(request) === keyFor(candidate)
-            )
-              apply(
-                rebindRequestId(result, request),
-                request,
-                Date.now(),
-                liveFlight,
-              );
-          })().catch((error) => {
-            const latestSuccessful = latestSuccessfulFlight.get(
-              keyFor(candidate),
-            );
-            if (
-              !isAbort(error) &&
-              active &&
-              !disposed &&
-              currentGeneration === liveGeneration &&
-              connection === connectionGeneration &&
-              request &&
-              keyFor(request) === keyFor(candidate) &&
-              (latestSuccessful === undefined || liveFlight > latestSuccessful)
-            )
-              publish({ ...state, error });
-          });
-        },
-        { signal: controller.signal },
-      );
+    let handle: ManagedLiveSubscription;
+    const disconnect = (): void => {
+      if (!connected) return;
+      connected = false;
+      controller.abort();
+      subscription.unsubscribe();
+      if (live === handle) live = undefined;
     };
     const unsubscribe = (): void => {
-      if (!active) return;
-      active = false;
-      liveGeneration += 1;
-      controller?.abort();
-      subscription.unsubscribe();
-      if (live === handle) {
-        live = undefined;
-        liveRequested = false;
-      }
+      if (!intent.active) return;
+      intent.active = false;
+      disconnect();
+      if (liveIntent === intent) liveIntent = undefined;
+      if (live?.intent === intent) live.disconnect();
     };
     const reconnect = (): void => {
-      if (!active || disposed || currentGeneration !== liveGeneration) return;
-      // Invalidate callbacks that already entered envelope validation before
-      // aborting this connection; the replacement is installed only after the
-      // background refetch settles.
-      const reconnectGeneration = ++connectionGeneration;
-      controller?.abort();
-      subscription.unsubscribe();
+      if (!intent.active || disposed) return;
+      if (!connected) {
+        if (live?.intent === intent) live.reconnect();
+        return;
+      }
+      if (currentGeneration !== liveGeneration) return;
+      disconnect();
       // Refresh the exact page first, then replace the old subscription. This
       // avoids reconnecting against a stale cursor or cached snapshot.
       void execute(candidate, { mode: 'background', force: true })
         .catch(() => undefined)
         .finally(() => {
           if (
-            active &&
+            intent.active &&
             !disposed &&
-            currentGeneration === liveGeneration &&
-            reconnectGeneration === connectionGeneration
+            liveIntent === intent &&
+            !live &&
+            request &&
+            keyFor(request) === keyFor(candidate)
           )
-            connect();
+            startLive(intent);
         });
     };
-    handle = { unsubscribe, reconnect };
-    connect();
+    handle = { intent, disconnect, unsubscribe, reconnect };
+    subscription = transport.subscribe(
+      candidate,
+      (raw) => {
+        if (
+          !connected ||
+          !intent.active ||
+          disposed ||
+          currentGeneration !== liveGeneration ||
+          controller.signal.aborted
+        )
+          return;
+        // Claim ordering when the push arrives, before envelope validation
+        // yields. A later explicit fetch must remain newer even if this
+        // callback resumes after it.
+        const liveFlight = ++flightSequence;
+        void (async () => {
+          const result = await executeSmrtWebDataQuery(
+            { query: async () => raw },
+            candidate,
+          );
+          if (
+            connected &&
+            intent.active &&
+            !disposed &&
+            currentGeneration === liveGeneration &&
+            request &&
+            keyFor(request) === keyFor(candidate)
+          )
+            apply(
+              rebindRequestId(result, request),
+              request,
+              Date.now(),
+              liveFlight,
+            );
+        })().catch((error) => {
+          const latestSuccessful = latestSuccessfulFlight.get(
+            keyFor(candidate),
+          );
+          if (
+            !isAbort(error) &&
+            connected &&
+            intent.active &&
+            !disposed &&
+            currentGeneration === liveGeneration &&
+            request &&
+            keyFor(request) === keyFor(candidate) &&
+            (latestSuccessful === undefined || liveFlight > latestSuccessful)
+          )
+            publish({ ...state, error });
+        });
+      },
+      { signal: controller.signal },
+    );
     live = handle;
-    liveRequested = true;
     return handle;
+  };
+  const subscribeLive = (): SmrtWebQueryLiveSubscription | undefined => {
+    if (disposed || !request || !transport.subscribe) return undefined;
+    if (liveIntent) {
+      liveIntent.active = false;
+      live?.disconnect();
+    }
+    const intent = { active: true };
+    liveIntent = intent;
+    try {
+      return startLive(intent);
+    } catch (error) {
+      intent.active = false;
+      if (liveIntent === intent) liveIntent = undefined;
+      throw error;
+    }
   };
   return {
     get state() {
@@ -583,9 +599,10 @@ export function createSmrtWebQuery<TData extends object>(
       liveGeneration += 1;
       visibleController?.abort(abortError());
       for (const controller of runControllers) controller.abort(abortError());
-      live?.unsubscribe();
+      if (liveIntent) liveIntent.active = false;
+      live?.disconnect();
       live = undefined;
-      liveRequested = false;
+      liveIntent = undefined;
       request = undefined;
       listeners.clear();
       cache.clear();

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -211,6 +211,13 @@ export function createSmrtWebQuery<TData extends object>(
         throw controller.signal.reason ?? abortError();
       }
       return result;
+    } catch (error) {
+      // A transport may reject with its own error instead of propagating the
+      // abort reason. Once cancelled, that transport error is not query state.
+      if (controller.signal.aborted) {
+        throw controller.signal.reason ?? abortError();
+      }
+      throw error;
     } finally {
       if (timer) clearTimeout(timer);
       for (const cleanup of cleanups) cleanup();

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -208,14 +208,14 @@ export function createSmrtWebQuery<TData extends object>(
       // authoritative after they resolve, so their result must not reach the
       // cache or visible state.
       if (controller.signal.aborted) {
-        throw controller.signal.reason ?? abortError();
+        throw abortError();
       }
       return result;
     } catch (error) {
       // A transport may reject with its own error instead of propagating the
       // abort reason. Once cancelled, that transport error is not query state.
       if (controller.signal.aborted) {
-        throw controller.signal.reason ?? abortError();
+        throw abortError();
       }
       throw error;
     } finally {

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -185,9 +185,16 @@ export function createSmrtWebQuery<TData extends object>(
         );
     }
     try {
-      return await executeSmrtWebDataQuery(transport, candidate, {
+      const result = await executeSmrtWebDataQuery(transport, candidate, {
         signal: controller.signal,
       });
+      // Some transports cannot observe AbortSignal. Cancellation remains
+      // authoritative after they resolve, so their result must not reach the
+      // cache or visible state.
+      if (controller.signal.aborted) {
+        throw controller.signal.reason ?? abortError();
+      }
+      return result;
     } finally {
       if (timer) clearTimeout(timer);
       for (const cleanup of cleanups) cleanup();

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -301,13 +301,31 @@ export function createSmrtWebQuery<TData extends object>(
         removeCallerAbort = () =>
           signal.removeEventListener('abort', abortCaller);
       }
-      publish({
-        ...state,
-        loading: entry === undefined,
-        refreshing: entry !== undefined,
-        stale: entry !== undefined,
-        error: null,
-      });
+      if (entry) {
+        // A keyed cache entry is a complete snapshot for its query. Do not
+        // carry rows, pagination, or totals over from whichever query was
+        // visible before this stale-while-revalidate request.
+        const cachedResult = rebindRequestId(entry.result, candidate);
+        publish({
+          rows: cachedResult.rows as TData[],
+          page: pageOf(cachedResult),
+          total: cachedResult.total,
+          loading: false,
+          refreshing: true,
+          stale: true,
+          error: null,
+          lastUpdated: entry.updatedAt,
+          result: cachedResult,
+        });
+      } else {
+        publish({
+          ...state,
+          loading: true,
+          refreshing: false,
+          stale: false,
+          error: null,
+        });
+      }
       // A visible run is a successor boundary: it must never adopt an older
       // same-key shared promise whose signal was just aborted above.
       runOptions = {
@@ -486,7 +504,13 @@ export function createSmrtWebQuery<TData extends object>(
       disconnect();
       // Refresh the exact page first, then replace the old subscription. This
       // avoids reconnecting against a stale cursor or cached snapshot.
-      void execute(candidate, { mode: 'visible', force: true })
+      // A same-key visible execution can update only correlation metadata.
+      // Reconnect must retain that most recent request id instead of reviving
+      // the one captured by the original subscription.
+      const reconnectRequest = request;
+      if (!reconnectRequest || keyFor(reconnectRequest) !== keyFor(candidate))
+        return;
+      void execute(reconnectRequest, { mode: 'visible', force: true })
         .catch(() => undefined)
         .finally(() => {
           if (

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -142,13 +142,27 @@ export function createSmrtWebQuery<TData extends object>(
     for (const listener of listeners) listener(state);
   };
   const cached = (key: string): CacheEntry | undefined => cache.get(key);
+  const cacheSuccess = (
+    key: string,
+    result: SmrtWebDataQueryResult,
+    sequence: number,
+    updatedAt = Date.now(),
+  ): void => {
+    if (disposed) return;
+    const latest = latestSuccessfulFlight.get(key);
+    if (latest === undefined || sequence > latest) {
+      latestSuccessfulFlight.set(key, sequence);
+      cache.set(key, { result, updatedAt });
+    }
+  };
   const apply = (
     result: SmrtWebDataQueryResult,
     candidate: SmrtWebDataQueryRequest,
     updatedAt = Date.now(),
+    successSequence?: number,
   ): void => {
-    const entry = { result, updatedAt };
-    cache.set(keyFor(candidate), entry);
+    if (successSequence !== undefined)
+      cacheSuccess(keyFor(candidate), result, successSequence, updatedAt);
     publish({
       rows: result.rows as TData[],
       page: pageOf(result),
@@ -292,11 +306,7 @@ export function createSmrtWebQuery<TData extends object>(
     const running = runTransport(candidate, runOptions).then((result) => {
       // A failed or aborted successor must not suppress an older valid result,
       // but a successful successor must win over any later predecessor.
-      const latest = latestSuccessfulFlight.get(key);
-      if (latest === undefined || flight > latest) {
-        latestSuccessfulFlight.set(key, flight);
-        cache.set(key, { result, updatedAt: Date.now() });
-      }
+      cacheSuccess(key, result, flight);
       return result;
     });
     inFlight.set(key, running);
@@ -363,7 +373,7 @@ export function createSmrtWebQuery<TData extends object>(
               request &&
               keyFor(request) === keyFor(candidate)
             )
-              apply(result, candidate);
+              apply(result, candidate, Date.now(), ++flightSequence);
           })().catch((error) => {
             if (
               !isAbort(error) &&
@@ -441,6 +451,7 @@ export function createSmrtWebQuery<TData extends object>(
       request = undefined;
       listeners.clear();
       cache.clear();
+      latestSuccessfulFlight.clear();
       inFlight.clear();
     },
   };

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -280,7 +280,7 @@ export function createSmrtWebQuery<TData extends object>(
       const result = rebindRequestId(entry.result, candidate);
       apply(result, candidate, entry.updatedAt);
       if (disposed) throw abortError();
-      if (rebindIntent?.active && !live) startLive(rebindIntent);
+      if (rebindIntent?.active && !live) resumeLive(rebindIntent);
       return result;
     }
     if (mode === 'visible') {
@@ -325,7 +325,7 @@ export function createSmrtWebQuery<TData extends object>(
         if (current === generation) {
           if (cached(key)?.result === result) apply(result, candidate);
           else publish({ ...state, loading: false, refreshing: false });
-          if (rebindIntent?.active && !live) startLive(rebindIntent);
+          if (rebindIntent?.active && !live) resumeLive(rebindIntent);
         }
         return result;
       } catch (error) {
@@ -497,7 +497,7 @@ export function createSmrtWebQuery<TData extends object>(
             request &&
             keyFor(request) === keyFor(candidate)
           )
-            startLive(intent);
+            resumeLive(intent);
         });
     };
     handle = { intent, disconnect, unsubscribe, reconnect };
@@ -561,6 +561,21 @@ export function createSmrtWebQuery<TData extends object>(
     live = handle;
     return handle;
   };
+  const clearLiveIntent = (intent: LiveIntent): void => {
+    intent.active = false;
+    if (liveIntent === intent) liveIntent = undefined;
+  };
+  const resumeLive = (intent: LiveIntent): void => {
+    try {
+      startLive(intent);
+    } catch (error) {
+      // An automatic rebind must not turn a successful cache/read result into
+      // a rejected execution, or leave a reconnect's detached promise
+      // unhandled. The caller can start a new live subscription explicitly.
+      clearLiveIntent(intent);
+      if (!disposed) publish({ ...state, error });
+    }
+  };
   const subscribeLive = (): SmrtWebQueryLiveSubscription | undefined => {
     if (disposed || !request || !transport.subscribe) return undefined;
     if (liveIntent) {
@@ -572,8 +587,7 @@ export function createSmrtWebQuery<TData extends object>(
     try {
       return startLive(intent);
     } catch (error) {
-      intent.active = false;
-      if (liveIntent === intent) liveIntent = undefined;
+      clearLiveIntent(intent);
       throw error;
     }
   };

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -448,6 +448,10 @@ export function createSmrtWebQuery<TData extends object>(
             controller?.signal.aborted
           )
             return;
+          // Claim ordering when the push arrives, before envelope validation
+          // yields. A later explicit fetch must remain newer even if this
+          // callback resumes after it.
+          const liveFlight = ++flightSequence;
           void (async () => {
             const result = await executeSmrtWebDataQuery(
               { query: async () => raw },
@@ -465,7 +469,7 @@ export function createSmrtWebQuery<TData extends object>(
                 rebindRequestId(result, request),
                 request,
                 Date.now(),
-                ++flightSequence,
+                liveFlight,
               );
           })().catch((error) => {
             if (

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -243,6 +243,8 @@ export function createSmrtWebQuery<TData extends object>(
   ): Promise<SmrtWebDataQueryResult> => {
     const mode = runOptions.mode ?? 'visible';
     const key = keyFor(candidate);
+    if (runOptions.signal?.aborted || (runOptions.deadlineMs ?? 1) <= 0)
+      throw abortError();
     const entry = cached(key);
     const fresh =
       entry !== undefined && Date.now() - entry.updatedAt < staleTimeMs;
@@ -472,6 +474,9 @@ export function createSmrtWebQuery<TData extends object>(
                 liveFlight,
               );
           })().catch((error) => {
+            const latestSuccessful = latestSuccessfulFlight.get(
+              keyFor(candidate),
+            );
             if (
               !isAbort(error) &&
               active &&
@@ -479,7 +484,8 @@ export function createSmrtWebQuery<TData extends object>(
               currentGeneration === liveGeneration &&
               connection === connectionGeneration &&
               request &&
-              keyFor(request) === keyFor(candidate)
+              keyFor(request) === keyFor(candidate) &&
+              (latestSuccessful === undefined || liveFlight > latestSuccessful)
             )
               publish({ ...state, error });
           });

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -74,6 +74,13 @@ interface CacheEntry {
   updatedAt: number;
 }
 
+interface SharedFlight {
+  controller: AbortController;
+  promise: Promise<SmrtWebDataQueryResult>;
+  waiters: number;
+  settled: boolean;
+}
+
 function canonicalize(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(canonicalize);
   if (value && typeof value === 'object') {
@@ -137,7 +144,7 @@ export function createSmrtWebQuery<TData extends object>(
 ): SmrtWebQuery<TData> {
   const staleTimeMs = options.staleTimeMs ?? 30_000;
   const cache = new Map<string, CacheEntry>();
-  const inFlight = new Map<string, Promise<SmrtWebDataQueryResult>>();
+  const inFlight = new Map<string, SharedFlight>();
   const latestSuccessfulFlight = new Map<string, number>();
   let flightSequence = 0;
   const listeners = new Set<(state: SmrtWebQueryState<TData>) => void>();
@@ -205,30 +212,9 @@ export function createSmrtWebQuery<TData extends object>(
   };
   const runTransport = async (
     candidate: SmrtWebDataQueryRequest,
-    runOptions: SmrtWebQueryRunOptions,
+    controller: AbortController,
   ): Promise<SmrtWebDataQueryResult> => {
-    const controller = new AbortController();
     runControllers.add(controller);
-    const cleanups: Array<() => void> = [];
-    const abortFrom = (signal: AbortSignal | undefined): void => {
-      if (!signal) return;
-      if (signal.aborted) controller.abort(signal.reason);
-      else {
-        const abort = () => controller.abort(signal.reason);
-        signal.addEventListener('abort', abort, { once: true });
-        cleanups.push(() => signal.removeEventListener('abort', abort));
-      }
-    };
-    abortFrom(runOptions.signal);
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    if (runOptions.deadlineMs !== undefined) {
-      if (runOptions.deadlineMs <= 0) controller.abort(abortError());
-      else
-        timer = setTimeout(
-          () => controller.abort(abortError()),
-          runOptions.deadlineMs,
-        );
-    }
     try {
       const result = await executeSmrtWebDataQuery(transport, candidate, {
         signal: controller.signal,
@@ -249,8 +235,6 @@ export function createSmrtWebQuery<TData extends object>(
       throw error;
     } finally {
       runControllers.delete(controller);
-      if (timer) clearTimeout(timer);
-      for (const cleanup of cleanups) cleanup();
     }
   };
   const execute = async (
@@ -339,36 +323,92 @@ export function createSmrtWebQuery<TData extends object>(
     }
     return runShared(candidate, key, runOptions);
   };
+  const waitForFlight = (
+    flight: SharedFlight,
+    key: string,
+    candidate: SmrtWebDataQueryRequest,
+    runOptions: SmrtWebQueryRunOptions,
+  ): Promise<SmrtWebDataQueryResult> => {
+    if (runOptions.signal?.aborted || (runOptions.deadlineMs ?? 1) <= 0)
+      return Promise.reject(abortError());
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const settle = (): void => {
+        if (settled) return;
+        settled = true;
+        flight.waiters -= 1;
+        if (timer) clearTimeout(timer);
+        runOptions.signal?.removeEventListener('abort', cancel);
+      };
+      const cancel = (): void => {
+        if (settled) return;
+        settle();
+        if (flight.waiters === 0 && !flight.settled) {
+          flight.controller.abort(abortError());
+          if (inFlight.get(key) === flight) inFlight.delete(key);
+        }
+        reject(abortError());
+      };
+      const timer =
+        runOptions.deadlineMs === undefined
+          ? undefined
+          : setTimeout(cancel, runOptions.deadlineMs);
+      flight.waiters += 1;
+      runOptions.signal?.addEventListener('abort', cancel, { once: true });
+      flight.promise.then(
+        (result) => {
+          if (settled) return;
+          settle();
+          resolve(rebindRequestId(result, candidate));
+        },
+        (error) => {
+          if (settled) return;
+          settle();
+          reject(error);
+        },
+      );
+    });
+  };
   const runShared = async (
     candidate: SmrtWebDataQueryRequest,
     key: string,
     runOptions: SmrtWebQueryRunOptions,
   ): Promise<SmrtWebDataQueryResult> => {
+    if (runOptions.signal?.aborted || (runOptions.deadlineMs ?? 1) <= 0)
+      throw abortError();
     if (!runOptions.force) {
-      const running = inFlight.get(key);
-      if (running)
-        return running.then((result) => rebindRequestId(result, candidate));
+      const existing = inFlight.get(key);
+      if (existing) return waitForFlight(existing, key, candidate, runOptions);
     }
     const flight = ++flightSequence;
-    const running = runTransport(candidate, runOptions).then((result) => {
+    const controller = new AbortController();
+    const running = runTransport(candidate, controller).then((result) => {
       // A failed or aborted successor must not suppress an older valid result,
       // but a successful successor must win over any later predecessor.
       cacheSuccess(key, result, flight);
       return result;
     });
-    inFlight.set(key, running);
+    const shared: SharedFlight = {
+      controller,
+      promise: running,
+      waiters: 0,
+      settled: false,
+    };
+    inFlight.set(key, shared);
     // A forced successor may replace this map entry while the predecessor is
     // still settling. Only the promise that currently owns the key may delete
     // it, otherwise a third caller can miss the active successor flight.
     void running.then(
       () => {
-        if (inFlight.get(key) === running) inFlight.delete(key);
+        shared.settled = true;
+        if (inFlight.get(key) === shared) inFlight.delete(key);
       },
       () => {
-        if (inFlight.get(key) === running) inFlight.delete(key);
+        shared.settled = true;
+        if (inFlight.get(key) === shared) inFlight.delete(key);
       },
     );
-    return running;
+    return waitForFlight(shared, key, candidate, runOptions);
   };
   const refresh = (
     refreshOptions: Omit<SmrtWebQueryRunOptions, 'mode' | 'force'> = {},

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -251,6 +251,7 @@ export function createSmrtWebQuery<TData extends object>(
     candidate: SmrtWebDataQueryRequest,
     runOptions: SmrtWebQueryRunOptions = {},
   ): Promise<SmrtWebDataQueryResult> => {
+    if (disposed) throw abortError();
     const mode = runOptions.mode ?? 'visible';
     const key = keyFor(candidate);
     if (runOptions.signal?.aborted || (runOptions.deadlineMs ?? 1) <= 0)

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -287,7 +287,11 @@ export function createSmrtWebQuery<TData extends object>(
       if (running) return running;
     }
     const running = runTransport(candidate, runOptions).then((result) => {
-      cache.set(key, { result, updatedAt: Date.now() });
+      // A forced successor can replace this flight before the predecessor
+      // settles. Only the current owner may publish to the keyed cache.
+      if (inFlight.get(key) === running) {
+        cache.set(key, { result, updatedAt: Date.now() });
+      }
       return result;
     });
     inFlight.set(key, running);

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -253,14 +253,20 @@ export function createSmrtWebQuery<TData extends object>(
         if (current === generation) apply(result, candidate);
         return result;
       } catch (error) {
-        if (current === generation && !isAbort(error)) {
-          publish({
-            ...state,
-            loading: false,
-            refreshing: false,
-            stale: entry !== undefined,
-            error,
-          });
+        if (current === generation) {
+          if (isAbort(error)) {
+            // Cancellation is not an error, but the current invocation must
+            // still release its busy state. Preserve all other state fields.
+            publish({ ...state, loading: false, refreshing: false });
+          } else {
+            publish({
+              ...state,
+              loading: false,
+              refreshing: false,
+              stale: entry !== undefined,
+              error,
+            });
+          }
         }
         throw error;
       } finally {

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -74,11 +74,33 @@ interface CacheEntry {
   updatedAt: number;
 }
 
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(record)
+        .sort()
+        .map((key) => [key, canonicalize(record[key])]),
+    );
+  }
+  return value;
+}
+
 function keyFor(request: SmrtWebDataQueryRequest): string {
   // requestId is correlation metadata, not query identity. Removing it allows
   // refreshes and independently-created equivalent requests to share a result.
   const { requestId: _requestId, ...semantic } = request;
-  return JSON.stringify(semantic);
+  return JSON.stringify(canonicalize(semantic));
+}
+
+function rebindRequestId(
+  result: SmrtWebDataQueryResult,
+  request: SmrtWebDataQueryRequest,
+): SmrtWebDataQueryResult {
+  return result.requestId === request.requestId
+    ? result
+    : { ...result, requestId: request.requestId };
 }
 
 function abortError(): DOMException | Error {
@@ -121,6 +143,7 @@ export function createSmrtWebQuery<TData extends object>(
   const listeners = new Set<(state: SmrtWebQueryState<TData>) => void>();
   let request: SmrtWebDataQueryRequest | undefined;
   let visibleController: AbortController | undefined;
+  const runControllers = new Set<AbortController>();
   let generation = 0;
   let live: SmrtWebQueryLiveSubscription | undefined;
   let liveGeneration = 0;
@@ -147,13 +170,15 @@ export function createSmrtWebQuery<TData extends object>(
     result: SmrtWebDataQueryResult,
     sequence: number,
     updatedAt = Date.now(),
-  ): void => {
-    if (disposed) return;
+  ): boolean => {
+    if (disposed) return false;
     const latest = latestSuccessfulFlight.get(key);
     if (latest === undefined || sequence > latest) {
       latestSuccessfulFlight.set(key, sequence);
       cache.set(key, { result, updatedAt });
+      return true;
     }
+    return false;
   };
   const apply = (
     result: SmrtWebDataQueryResult,
@@ -161,8 +186,11 @@ export function createSmrtWebQuery<TData extends object>(
     updatedAt = Date.now(),
     successSequence?: number,
   ): void => {
-    if (successSequence !== undefined)
-      cacheSuccess(keyFor(candidate), result, successSequence, updatedAt);
+    if (
+      successSequence !== undefined &&
+      !cacheSuccess(keyFor(candidate), result, successSequence, updatedAt)
+    )
+      return;
     publish({
       rows: result.rows as TData[],
       page: pageOf(result),
@@ -180,6 +208,7 @@ export function createSmrtWebQuery<TData extends object>(
     runOptions: SmrtWebQueryRunOptions,
   ): Promise<SmrtWebDataQueryResult> => {
     const controller = new AbortController();
+    runControllers.add(controller);
     const cleanups: Array<() => void> = [];
     const abortFrom = (signal: AbortSignal | undefined): void => {
       if (!signal) return;
@@ -219,6 +248,7 @@ export function createSmrtWebQuery<TData extends object>(
       }
       throw error;
     } finally {
+      runControllers.delete(controller);
       if (timer) clearTimeout(timer);
       for (const cleanup of cleanups) cleanup();
     }
@@ -232,14 +262,16 @@ export function createSmrtWebQuery<TData extends object>(
     const entry = cached(key);
     const fresh =
       entry !== undefined && Date.now() - entry.updatedAt < staleTimeMs;
-    if (mode !== 'visible' && !runOptions.force && fresh) return entry.result;
+    if (mode !== 'visible' && !runOptions.force && fresh)
+      return rebindRequestId(entry.result, candidate);
     if (mode === 'visible' && !runOptions.force && fresh) {
       generation += 1;
       visibleController?.abort(abortError());
       visibleController = undefined;
       request = candidate;
-      apply(entry.result, candidate, entry.updatedAt);
-      return entry.result;
+      const result = rebindRequestId(entry.result, candidate);
+      apply(result, candidate, entry.updatedAt);
+      return result;
     }
     if (mode === 'visible') {
       generation += 1;
@@ -273,7 +305,10 @@ export function createSmrtWebQuery<TData extends object>(
       };
       try {
         const result = await runShared(candidate, key, runOptions);
-        if (current === generation) apply(result, candidate);
+        // A query-scoped live update may have won while this transport was in
+        // flight. Only apply the result when it is still the cache's winner.
+        if (current === generation && cached(key)?.result === result)
+          apply(result, candidate);
         return result;
       } catch (error) {
         if (current === generation) {
@@ -445,14 +480,17 @@ export function createSmrtWebQuery<TData extends object>(
       if (!request) return;
       const key = keyFor(request);
       const entry = cache.get(key);
+      // A response that started before invalidation cannot restore freshness.
+      latestSuccessfulFlight.set(key, ++flightSequence);
       if (entry) cache.set(key, { ...entry, updatedAt: 0 });
-      publish({ ...state, stale: true });
+      publish({ ...state, loading: false, refreshing: false, stale: true });
     },
     dispose() {
       disposed = true;
       generation += 1;
       liveGeneration += 1;
       visibleController?.abort(abortError());
+      for (const controller of runControllers) controller.abort(abortError());
       live?.unsubscribe();
       live = undefined;
       request = undefined;

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -461,7 +461,12 @@ export function createSmrtWebQuery<TData extends object>(
               request &&
               keyFor(request) === keyFor(candidate)
             )
-              apply(result, candidate, Date.now(), ++flightSequence);
+              apply(
+                rebindRequestId(result, request),
+                request,
+                Date.now(),
+                ++flightSequence,
+              );
           })().catch((error) => {
             if (
               !isAbort(error) &&
@@ -491,7 +496,7 @@ export function createSmrtWebQuery<TData extends object>(
       // Invalidate callbacks that already entered envelope validation before
       // aborting this connection; the replacement is installed only after the
       // background refetch settles.
-      connectionGeneration += 1;
+      const reconnectGeneration = ++connectionGeneration;
       controller?.abort();
       subscription.unsubscribe();
       // Refresh the exact page first, then replace the old subscription. This
@@ -499,7 +504,12 @@ export function createSmrtWebQuery<TData extends object>(
       void execute(candidate, { mode: 'background', force: true })
         .catch(() => undefined)
         .finally(() => {
-          if (active && !disposed && currentGeneration === liveGeneration)
+          if (
+            active &&
+            !disposed &&
+            currentGeneration === liveGeneration &&
+            reconnectGeneration === connectionGeneration
+          )
             connect();
         });
     };

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -346,7 +346,8 @@ export function createSmrtWebQuery<TData extends object>(
   ): Promise<SmrtWebDataQueryResult> => {
     if (!runOptions.force) {
       const running = inFlight.get(key);
-      if (running) return running;
+      if (running)
+        return running.then((result) => rebindRequestId(result, candidate));
     }
     const flight = ++flightSequence;
     const running = runTransport(candidate, runOptions).then((result) => {

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -279,6 +279,7 @@ export function createSmrtWebQuery<TData extends object>(
       if (rebindIntent) live?.disconnect();
       const result = rebindRequestId(entry.result, candidate);
       apply(result, candidate, entry.updatedAt);
+      if (disposed) throw abortError();
       if (rebindIntent?.active && !live) startLive(rebindIntent);
       return result;
     }
@@ -485,7 +486,7 @@ export function createSmrtWebQuery<TData extends object>(
       disconnect();
       // Refresh the exact page first, then replace the old subscription. This
       // avoids reconnecting against a stale cursor or cached snapshot.
-      void execute(candidate, { mode: 'background', force: true })
+      void execute(candidate, { mode: 'visible', force: true })
         .catch(() => undefined)
         .finally(() => {
           if (
@@ -553,6 +554,10 @@ export function createSmrtWebQuery<TData extends object>(
       },
       { signal: controller.signal },
     );
+    if (disposed || !intent.active) {
+      disconnect();
+      return undefined;
+    }
     live = handle;
     return handle;
   };

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -273,6 +273,7 @@ export function createSmrtWebQuery<TData extends object>(
     if (mode === 'visible' && !runOptions.force && fresh) {
       generation += 1;
       visibleController?.abort(abortError());
+      if (disposed) throw abortError();
       visibleController = undefined;
       request = candidate;
       if (rebindIntent) live?.disconnect();
@@ -284,6 +285,7 @@ export function createSmrtWebQuery<TData extends object>(
     if (mode === 'visible') {
       generation += 1;
       visibleController?.abort(abortError());
+      if (disposed) throw abortError();
       const invocationController = new AbortController();
       visibleController = invocationController;
       request = candidate;
@@ -313,6 +315,7 @@ export function createSmrtWebQuery<TData extends object>(
         force: true,
       };
       try {
+        if (disposed) throw abortError();
         const result = await runShared(candidate, key, runOptions);
         // A query-scoped live update or background successor may have won
         // while this transport was in flight. Do not let the older visible

--- a/packages/smrt-web/src/remote-query.ts
+++ b/packages/smrt-web/src/remote-query.ts
@@ -245,6 +245,13 @@ export function createSmrtWebQuery<TData extends object>(
     const key = keyFor(candidate);
     if (runOptions.signal?.aborted || (runOptions.deadlineMs ?? 1) <= 0)
       throw abortError();
+    // A live connection is scoped to the complete semantic query, not merely
+    // the controller. Preserve it for a request-id rebinding, but replace it
+    // when visible state moves to a different page, filter, or sort.
+    const previousLive =
+      mode === 'visible' && request && live && keyFor(request) !== key
+        ? live
+        : undefined;
     const entry = cached(key);
     const fresh =
       entry !== undefined && Date.now() - entry.updatedAt < staleTimeMs;
@@ -255,8 +262,10 @@ export function createSmrtWebQuery<TData extends object>(
       visibleController?.abort(abortError());
       visibleController = undefined;
       request = candidate;
+      previousLive?.unsubscribe();
       const result = rebindRequestId(entry.result, candidate);
       apply(result, candidate, entry.updatedAt);
+      if (previousLive && !live) subscribeLive();
       return result;
     }
     if (mode === 'visible') {
@@ -265,6 +274,7 @@ export function createSmrtWebQuery<TData extends object>(
       const invocationController = new AbortController();
       visibleController = invocationController;
       request = candidate;
+      previousLive?.unsubscribe();
       const current = generation;
       const signal = runOptions.signal;
       let removeCallerAbort: (() => void) | undefined;
@@ -298,6 +308,7 @@ export function createSmrtWebQuery<TData extends object>(
         if (current === generation) {
           if (cached(key)?.result === result) apply(result, candidate);
           else publish({ ...state, loading: false, refreshing: false });
+          if (previousLive && !live) subscribeLive();
         }
         return result;
       } catch (error) {


### PR DESCRIPTION
## Summary

- Recover the remote-query controller and Svelte reactive binding under a fresh valid #2509 lifecycle.
- Provide keyed caching, per-caller cancellation, ordered live updates, reconnect handling, and disposal-safe teardown.
- Cover web and Svelte integration behavior, including automatic live-bind failure recovery.

Closes #2509

## Recovery scope

Refs #2445. The original #2498 pull request and its immutable claim/heartbeat history remain untouched.

## Validation

- `pnpm build`
- `pnpm test` — 4,133 passed, 113 skipped
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm smrt dev:knowledge-check`
- `pnpm audit:policy`
- Focused `@happyvertical/smrt-web` remote-query suite — 199 passed
- Independent exact-head review — clean

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "cab96bb1-ff87-45d0-b671-0001158cb5f3",
  "issue": 2509,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "pnpm build",
    "pnpm test",
    "pnpm typecheck",
    "pnpm smrt dev:knowledge-check",
    "pnpm audit:policy",
    "independent exact-head review"
  ]
}
```