### PR TITLE
feat(core): emit canonical WebMCP tool definitions

### DIFF
--- a/packages/core/agents/generators.md
+++ b/packages/core/agents/generators.md
@@ -13,6 +13,14 @@ invariants, and the traps that apply before editing anything live in
 | MCP Server | `src/generators/mcp.ts` | Model Context Protocol tools |
 | Web collections | `src/vite-plugin/web-collections.ts` (selectors) + `generateWebModule` | `@happyvertical/smrt-virt-web` — one typed collection definition per API-exposed REST collection (#1761), consumed by `@happyvertical/smrt-web` |
 
+The same web virtual module exports `webMcpToolDefinitions` (#2518), a
+canonical per-tool array selected independently of list materialization. Every
+non-empty canonical API action set contributes tools, so get-only and
+custom-action-only models are discoverable; custom actions declared on a
+`SmrtCollection` merge into the owning row collection. Each definition carries
+complete route and invalidation metadata. `collectionDefinitions` and its
+embedded descriptor copy remain unchanged for existing cache-backed consumers.
+
 Generated API clients share `selectApiClientEntries()` across the runtime Vite
 module, its ambient declaration, and physical prebuild declarations. When a
 collection class and its populated model share an endpoint, the model owns the
@@ -24,6 +32,9 @@ qualified names first, then package-local simple names, then a stable identity
 fallback so duplicate class names across packages cannot reintroduce ordering.
 
 The web module also emits a build-time **`manifestHash`** constant (#1764): `computeWebManifestHash(manifest)` is a deterministic, replica-stable digest of the emitted web-collection SHAPE (name/className/endpoint/idField/actions/fields/relationships), canonicalized (recursive key sort) before `sha256 → base64url`, truncated to 16 chars — so the same schema always hashes the same, and a field add/remove/type-change/edge-change changes it. A change means old persisted client rows may mis-hydrate, so smrt-web keys its durable persistence namespace on it and its `updateAvailable` contract signal compares against it. Four co-managed emission sites must not drift: the runtime value (`generateWebModule`), the `@happyvertical/smrt-virt-web` ambient d.ts (`vite-plugin/index.ts`), the physical `@smrt/web` d.ts (`prebuild/index.ts`), and the hand-written type mirror in `@happyvertical/smrt-web` (`packages/smrt-web/src/index.ts` — dependency-free, so textual sync only).
+
+`webMcpToolDefinitions` is deliberately outside that digest: tool-only route,
+identifier, or annotation changes cannot alter persisted row hydration.
 
 Per-field web emission (#2046): `buildWebFieldDefinitions` carries `description` (from `@field({ description })`) and sanitized `ui` hints (from `@field({ ui: { basic, group, order, locked } })`, read off the manifest `_meta.ui` bag through per-key type guards) into each emitted field definition, and `buildWebToolDescriptors` threads the same `description` into browser MCP tool schemas. `sensitive`/`transient` fields are excluded from emission entirely, so their descriptions never ship. Both keys are conditional, so hint-less schemas emit byte-identical definitions (and hashes) as before; adding a description/ui hint changes the manifest hash — deliberate over-invalidation, harmless per the #1764 contract.
 

--- a/packages/core/src/prebuild/index.test.ts
+++ b/packages/core/src/prebuild/index.test.ts
@@ -214,6 +214,10 @@ describe('generateDeclarations', () => {
     expect(webDecl).toContain('objectRef: string;');
     expect(webDecl).toContain('description?: string;');
     expect(webDecl).toContain('ui?: SmrtWebFieldUIHints;');
+    expect(webDecl).toContain('export interface WebMcpToolDefinition');
+    expect(webDecl).toContain(
+      'export const webMcpToolDefinitions: readonly WebMcpToolDefinition[];',
+    );
 
     const sourceFile = ts.createSourceFile(
       'generated-virtual-modules.d.ts',
@@ -232,6 +236,49 @@ describe('generateDeclarations', () => {
         (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error,
       ),
     ).toEqual([]);
+  });
+
+  it('keeps every WebMCP definition declaration surface in sync', async () => {
+    await generateDeclarations({
+      manifest: buildManifest(),
+      outDir,
+      includeVirtualModules: true,
+      includeObjectTypes: true,
+    });
+
+    const declarationSurfaces = [
+      readFileSync(join(outDir, 'smrt-web.d.ts'), 'utf-8'),
+      readFileSync(
+        new URL('../vite-plugin/index.ts', import.meta.url),
+        'utf-8',
+      ),
+    ];
+    const typeSurfaces = [
+      ...declarationSurfaces,
+      readFileSync(
+        new URL('../../../smrt-web/src/index.ts', import.meta.url),
+        'utf-8',
+      ),
+    ];
+    const sharedMembers = [
+      'collection: string;',
+      'objectRef: string;',
+      'className: string;',
+      'endpoint: string;',
+      'idField: string;',
+      "idType: 'uuid' | 'text';",
+      'relationships: SmrtWebRelationship[];',
+    ];
+
+    for (const surface of declarationSurfaces) {
+      expect(surface).toContain('webMcpToolDefinitions');
+    }
+
+    for (const surface of typeSurfaces) {
+      expect(surface).toContain('interface WebMcpToolDefinition');
+      for (const member of sharedMembers) expect(surface).toContain(member);
+      expect(surface).toMatch(/route: (?:Smrt)?WebToolRouteDescriptor;/);
+    }
   });
 
   it('types canonical collection endpoints from populated models regardless of manifest order', async () => {

--- a/packages/core/src/prebuild/index.ts
+++ b/packages/core/src/prebuild/index.ts
@@ -388,6 +388,18 @@ declare module '@smrt/web' {
     route?: WebToolRouteDescriptor;
   }
 
+  /** Canonical data-only definition for one generated browser tool. */
+  export interface WebMcpToolDefinition extends WebToolDescriptor {
+    collection: string;
+    objectRef: string;
+    className: string;
+    endpoint: string;
+    idField: string;
+    idType: 'uuid' | 'text';
+    route: WebToolRouteDescriptor;
+    relationships: SmrtWebRelationship[];
+  }
+
   export interface SmrtWebCollectionDefinition<TData = Record<string, unknown>> {
     name: string;
     /** Canonical qualified model identity (\`@package/name:ClassName\`) for policy APIs. */
@@ -410,6 +422,8 @@ ${webCollectionEntries}
   }
 
   export const collectionDefinitions: SmrtWebCollectionDefinitions;
+  /** Every API-backed WebMCP tool, independent of list materialization. */
+  export const webMcpToolDefinitions: readonly WebMcpToolDefinition[];
   export function getCollectionDefinition<
     K extends keyof SmrtWebCollectionDefinitions,
   >(name: K): SmrtWebCollectionDefinitions[K];

--- a/packages/core/src/vite-plugin/index.ts
+++ b/packages/core/src/vite-plugin/index.ts
@@ -41,6 +41,7 @@ import {
 } from './sveltekit-generator.js';
 import {
   buildWebCollectionDefinition,
+  buildWebMcpToolDefinitions,
   buildWebToolDescriptors,
   computeWebManifestHash,
   selectWebCollectionEntries,
@@ -1329,12 +1330,17 @@ function generateWebModule(
   // the generated read ETag folds it in (a shape-only deploy busts validators).
   // Built via the shared selectors so it can never disagree with what ships.
   const manifestHash = computeWebManifestHash(manifest);
+  const webMcpToolDefinitions = buildWebMcpToolDefinitions(manifest, options);
 
   return `
 // Auto-generated web collection definitions from SMRT objects (#1761)
 // This file is generated automatically - do not edit
 
 export const collectionDefinitions = ${JSON.stringify(definitions, null, 2)};
+
+// Canonical browser-tool definitions. This export is independent of list
+// materialization, so get-only and custom-action-only API routes are included.
+export const webMcpToolDefinitions = ${JSON.stringify(webMcpToolDefinitions, null, 2)};
 
 // Build-time inject of the web-collection shape digest (#1764) — see
 // computeWebManifestHash. A change here means old persisted client rows may
@@ -1898,6 +1904,18 @@ declare module '@happyvertical/smrt-virt-web' {
     route?: WebToolRouteDescriptor;
   }
 
+  /** Canonical data-only definition for one generated browser tool. */
+  export interface WebMcpToolDefinition extends WebToolDescriptor {
+    collection: string;
+    objectRef: string;
+    className: string;
+    endpoint: string;
+    idField: string;
+    idType: 'uuid' | 'text';
+    route: WebToolRouteDescriptor;
+    relationships: SmrtWebRelationship[];
+  }
+
   export interface SmrtWebCollectionDefinition<TData = Record<string, unknown>> {
     name: string;
     /** Canonical qualified model identity (\`@package/name:ClassName\`) for policy APIs. */
@@ -1920,6 +1938,8 @@ ${webCollectionInterface}
   }
 
   export const collectionDefinitions: SmrtWebCollectionDefinitions;
+  /** Every API-backed WebMCP tool, independent of list materialization. */
+  export const webMcpToolDefinitions: readonly WebMcpToolDefinition[];
   export function getCollectionDefinition<
     K extends keyof SmrtWebCollectionDefinitions,
   >(name: K): SmrtWebCollectionDefinitions[K];

--- a/packages/core/src/vite-plugin/web-collections.test.ts
+++ b/packages/core/src/vite-plugin/web-collections.test.ts
@@ -18,6 +18,7 @@ import type {
 import {
   buildWebCollectionDefinition,
   buildWebFieldDefinitions,
+  buildWebMcpToolDefinitions,
   buildWebRelationships,
   buildWebToolDescriptors,
   computeWebManifestHash,
@@ -25,6 +26,7 @@ import {
   resolveCollectionItemObject,
   resolveCollectionItemTypeName,
   selectWebCollectionEntries,
+  selectWebMcpToolEntries,
 } from './web-collections.js';
 
 type ObjInput = Partial<SmartObjectDefinition> & {
@@ -460,6 +462,257 @@ describe('buildWebToolDescriptors', () => {
       legacyManifest,
     );
     expect(definition.objectRef).toBe('@example/products:Product');
+  });
+});
+
+describe('canonical WebMCP tool definitions (#2518)', () => {
+  const publicMethod = (
+    name: string,
+    options: {
+      isStatic?: boolean;
+      parameters?: SmartObjectDefinition['methods'][string]['parameters'];
+    } = {},
+  ): SmartObjectDefinition['methods'][string] => ({
+    name,
+    isPublic: true,
+    isStatic: options.isStatic ?? false,
+    async: true,
+    returnType: 'Promise<void>',
+    parameters: options.parameters ?? [],
+  });
+
+  it('emits get-only and custom-action-only object tools without materializing collections', () => {
+    const product = obj({
+      className: 'Product',
+      collection: 'products',
+      decoratorConfig: { api: { include: ['get'] } },
+    });
+    const report = obj({
+      className: 'Report',
+      collection: 'reports',
+      methods: {
+        refresh: publicMethod('refresh', {
+          isStatic: true,
+          parameters: [{ name: 'options', type: 'object', optional: true }],
+        }),
+      },
+      decoratorConfig: {
+        api: {
+          include: ['refresh'],
+          routes: {
+            refresh: {
+              method: 'PATCH',
+              scope: 'collection',
+              path: 'refresh-now',
+            },
+          },
+        },
+      } as SmartObjectDefinition['decoratorConfig'],
+    });
+    const m = manifest(product, report);
+
+    expect(selectWebCollectionEntries(m)).toEqual([]);
+    expect(buildWebMcpToolDefinitions(m)).toMatchObject([
+      {
+        collection: 'products',
+        action: 'get',
+        name: 'product_get',
+        route: { method: 'GET', scope: 'item', path: [] },
+      },
+      {
+        collection: 'reports',
+        action: 'refresh',
+        name: 'report_refresh',
+        route: {
+          method: 'PATCH',
+          scope: 'collection',
+          path: ['refresh-now'],
+          optionsBag: true,
+        },
+      },
+    ]);
+  });
+
+  it('merges collection-class custom actions into the owning row collection', () => {
+    const product = obj({
+      className: 'Product',
+      collection: 'products',
+      decoratorConfig: { api: false },
+    });
+    const products = obj({
+      className: 'ProductCollection',
+      collection: 'products',
+      extends: 'SmrtCollection',
+      extendsTypeArg: 'Product',
+      methods: {
+        publish: publicMethod('publish', {
+          parameters: [{ name: 'id', type: 'string', optional: false }],
+        }),
+      },
+      decoratorConfig: {
+        api: {
+          include: ['publish'],
+          routes: {
+            publish: {
+              method: 'POST',
+              scope: 'collection',
+              path: 'publish/[batchId]',
+            },
+          },
+        },
+      } as SmartObjectDefinition['decoratorConfig'],
+    });
+
+    const [definition] = buildWebMcpToolDefinitions(
+      manifest(products, product),
+    );
+    expect(definition).toMatchObject({
+      collection: 'products',
+      objectRef: '@happyvertical/smrt-core:Product',
+      className: 'Product',
+      action: 'publish',
+      name: 'product_publish',
+      route: {
+        method: 'POST',
+        scope: 'collection',
+        path: ['publish', '[batchId]'],
+        parameterAliases: { actionId: 'id' },
+      },
+    });
+    expect(definition?.inputSchema).toMatchObject({
+      properties: { actionId: { type: 'string' } },
+      required: ['actionId'],
+    });
+  });
+
+  it('honors API disablement, empty includes, exclusions, and ignores CLI/MCP-only exposure', () => {
+    const definitions = buildWebMcpToolDefinitions(
+      manifest(
+        obj({
+          className: 'Disabled',
+          collection: 'disabled',
+          decoratorConfig: { api: false, mcp: true, cli: true },
+        }),
+        obj({
+          className: 'Empty',
+          collection: 'empty',
+          decoratorConfig: { api: { include: [] } },
+        }),
+        obj({
+          className: 'Excluded',
+          collection: 'excluded',
+          decoratorConfig: {
+            api: { include: ['get'], exclude: ['get'] },
+          },
+        }),
+      ),
+    );
+
+    expect(definitions).toEqual([]);
+  });
+
+  it('uses public DTO fields and finalized bounded schemas', () => {
+    const definitions = buildWebMcpToolDefinitions(
+      manifest(
+        obj({
+          className: 'Product',
+          collection: 'products',
+          fields: {
+            name: { type: 'text', required: true } as FieldDefinition,
+            secret: { type: 'text', sensitive: true } as FieldDefinition,
+            scratch: { type: 'text', transient: true } as FieldDefinition,
+            metadata: { type: 'meta' } as FieldDefinition,
+            items: { type: 'oneToMany', related: 'Item' } as FieldDefinition,
+          },
+          decoratorConfig: { api: { include: ['create'] } },
+        }),
+      ),
+    );
+    const schema = definitions[0]?.inputSchema as {
+      $schema?: string;
+      properties?: Record<string, unknown>;
+    };
+
+    expect(schema.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
+    expect(Object.keys(schema.properties ?? {})).toEqual(['name']);
+  });
+
+  it('is scan-order independent and gives an object action precedence over a collection action collision', () => {
+    const product = obj({
+      className: 'Product',
+      collection: 'products',
+      methods: { publish: publicMethod('publish', { isStatic: true }) },
+      decoratorConfig: {
+        api: {
+          include: ['publish'],
+          routes: { publish: { path: 'object-publish' } },
+        },
+      } as SmartObjectDefinition['decoratorConfig'],
+    });
+    const products = obj({
+      className: 'ProductCollection',
+      collection: 'products',
+      extends: 'SmrtCollection',
+      extendsTypeArg: 'Product',
+      methods: { publish: publicMethod('publish') },
+      decoratorConfig: {
+        api: {
+          include: ['publish'],
+          routes: { publish: { path: 'collection-publish' } },
+        },
+      } as SmartObjectDefinition['decoratorConfig'],
+    });
+
+    const forward = manifest(product, products);
+    const reverse = manifest(products, product);
+    expect(selectWebMcpToolEntries(forward)).toHaveLength(1);
+    expect(buildWebMcpToolDefinitions(forward)).toEqual(
+      buildWebMcpToolDefinitions(reverse),
+    );
+    expect(buildWebMcpToolDefinitions(forward)[0]?.route.path).toEqual([
+      'object-publish',
+    ]);
+  });
+
+  it('keeps unique STI child actions while the base owns shared CRUD tools', () => {
+    const animal = obj({
+      className: 'Animal',
+      collection: 'animals',
+      decoratorConfig: { api: false, tableStrategy: 'sti' },
+    });
+    const cat = obj({
+      className: 'Cat',
+      collection: 'animals',
+      extends: 'Animal',
+      methods: { groom: publicMethod('groom') },
+      decoratorConfig: { api: { include: ['get', 'groom'] } },
+    });
+
+    const definitions = buildWebMcpToolDefinitions(manifest(cat, animal));
+    expect(
+      definitions.map(({ action, className, name }) => ({
+        action,
+        className,
+        name,
+      })),
+    ).toEqual([
+      { action: 'get', className: 'Animal', name: 'animal_get' },
+      { action: 'groom', className: 'Animal', name: 'animal_groom' },
+    ]);
+    expect(definitions[1]?.route.scope).toBe('item');
+  });
+
+  it('does not add WebMCP-only inputs to the row-shape manifest hash', () => {
+    const getOnly = obj({
+      className: 'Lookup',
+      collection: 'lookups',
+      decoratorConfig: { api: { include: ['get'] } },
+    });
+    const before = computeWebManifestHash(manifest(getOnly));
+    getOnly.decoratorConfig.idType = 'text';
+    getOnly.methods.lookup = publicMethod('lookup');
+
+    expect(computeWebManifestHash(manifest(getOnly))).toBe(before);
   });
 });
 

--- a/packages/core/src/vite-plugin/web-collections.test.ts
+++ b/packages/core/src/vite-plugin/web-collections.test.ts
@@ -580,8 +580,60 @@ describe('canonical WebMCP tool definitions (#2518)', () => {
       },
     });
     expect(definition?.inputSchema).toMatchObject({
-      properties: { actionId: { type: 'string' } },
-      required: ['actionId'],
+      properties: {
+        actionId: { type: 'string' },
+        batchId: { type: 'string' },
+      },
+      required: ['actionId', 'batchId'],
+    });
+  });
+
+  it('matches the last emitted collection-class route owner on a shared action', () => {
+    const product = obj({
+      className: 'Product',
+      collection: 'products',
+      decoratorConfig: { api: false },
+    });
+    const baseCollection = obj({
+      className: 'ProductCollection',
+      collection: 'products',
+      extends: 'SmrtCollection',
+      extendsTypeArg: 'Product',
+      methods: { search: publicMethod('search') },
+      decoratorConfig: {
+        api: { include: ['search'], routes: { search: { path: 'base' } } },
+      } as SmartObjectDefinition['decoratorConfig'],
+    });
+    const specializedCollection = obj({
+      className: 'SpecialProductCollection',
+      collection: 'products',
+      extends: 'ProductCollection',
+      methods: { search: publicMethod('search') },
+      decoratorConfig: {
+        api: {
+          include: ['search'],
+          routes: { search: { path: 'specialized' } },
+        },
+      } as SmartObjectDefinition['decoratorConfig'],
+    });
+
+    const forward = buildWebMcpToolDefinitions(
+      manifest(product, baseCollection, specializedCollection),
+    );
+    const reverse = buildWebMcpToolDefinitions(
+      manifest(product, specializedCollection, baseCollection),
+    );
+    expect(forward[0]).toMatchObject({
+      collection: 'products',
+      action: 'search',
+      name: 'product_search',
+      route: { path: ['specialized'] },
+    });
+    expect(reverse[0]).toMatchObject({
+      collection: 'products',
+      action: 'search',
+      name: 'product_search',
+      route: { path: ['base'] },
     });
   });
 

--- a/packages/core/src/vite-plugin/web-collections.ts
+++ b/packages/core/src/vite-plugin/web-collections.ts
@@ -29,6 +29,7 @@ import {
 } from '../generators/custom-action.js';
 import {
   buildToolDescriptors,
+  finalizeMcpJsonSchema,
   isCrudAction,
   type ToolDescriptor,
   type ToolFieldMeta,
@@ -589,7 +590,8 @@ function resolveStiCollectionOwner(
 export function selectWebMcpToolEntries(
   manifest: SmartObjectManifest,
 ): WebMcpToolEntry[] {
-  const sortedObjects = Object.values(manifest.objects).sort((left, right) =>
+  const manifestObjects = Object.values(manifest.objects);
+  const sortedObjects = [...manifestObjects].sort((left, right) =>
     compareText(
       webCollectionObjectRef(manifest, left),
       webCollectionObjectRef(manifest, right),
@@ -657,7 +659,11 @@ export function selectWebMcpToolEntries(
     }
   }
 
-  for (const collectionClass of sortedObjects) {
+  // SvelteKit emits collection-class routes in manifest order and a later
+  // class replaces an earlier handler at the same path. Follow that ownership
+  // rule so the selected parameter/route metadata describes the live handler.
+  // Object actions remain authoritative over collection-class collisions.
+  for (const collectionClass of manifestObjects) {
     if (!isCollectionManifestClass(manifest, collectionClass)) continue;
     const itemObject = resolveCollectionItemObject(manifest, collectionClass);
     if (!itemObject) continue;
@@ -669,7 +675,13 @@ export function selectWebMcpToolEntries(
       ...resolveApiActionSet(collectionClass, manifest),
     ].sort(compareText)) {
       const identity = `${collectionClass.collection}\0${action}`;
-      if (entries.has(identity)) continue;
+      const existing = entries.get(identity);
+      if (
+        existing &&
+        !isCollectionManifestClass(manifest, existing.actionHost)
+      ) {
+        continue;
+      }
       entries.set(identity, {
         collection: collectionClass.collection,
         obj: owner,
@@ -688,6 +700,52 @@ export function selectWebMcpToolEntries(
         webCollectionObjectRef(manifest, right.actionHost),
       ),
   );
+}
+
+function requireRoutePathInputs(
+  descriptor: ToolDescriptor | undefined,
+): ToolDescriptor | undefined {
+  if (!descriptor) return undefined;
+  const route = descriptor.route;
+  if (!route) return descriptor;
+
+  const pathParameters = route.path
+    .filter((segment) => /^\[[^\]]+\]$/.test(segment))
+    .map((segment) => segment.slice(1, -1));
+  if (pathParameters.length === 0) return descriptor;
+
+  const schema = descriptor.inputSchema;
+  const properties = {
+    ...((schema.properties as Record<string, unknown> | undefined) ?? {}),
+  };
+  const required = new Set(
+    Array.isArray(schema.required)
+      ? schema.required.filter(
+          (name): name is string => typeof name === 'string',
+        )
+      : [],
+  );
+
+  for (const parameterName of pathParameters) {
+    const inputName =
+      Object.entries(route.parameterAliases ?? {}).find(
+        ([, originalName]) => originalName === parameterName,
+      )?.[0] ?? parameterName;
+    properties[inputName] ??= {
+      type: 'string',
+      description: `Required route parameter: ${parameterName}`,
+    };
+    required.add(inputName);
+  }
+
+  return {
+    ...descriptor,
+    inputSchema: finalizeMcpJsonSchema({
+      ...schema,
+      properties,
+      required: [...required],
+    }),
+  };
 }
 
 /**
@@ -1015,13 +1073,15 @@ export function buildWebMcpToolDefinition(
   manifest: SmartObjectManifest,
   options: { kebabRoutes?: boolean } = {},
 ): WebMcpToolDefinition {
-  const descriptor = buildWebToolDescriptorsForHost({
-    owner: entry.obj,
-    actionHost: entry.actionHost,
-    actions: [entry.action],
-    options,
-    collectionHost: isCollectionManifestClass(manifest, entry.actionHost),
-  })[0];
+  const descriptor = requireRoutePathInputs(
+    buildWebToolDescriptorsForHost({
+      owner: entry.obj,
+      actionHost: entry.actionHost,
+      actions: [entry.action],
+      options,
+      collectionHost: isCollectionManifestClass(manifest, entry.actionHost),
+    })[0],
+  );
   if (!descriptor) {
     throw new Error(
       `[smrt] Failed to build WebMCP descriptor for ${entry.collection}.${entry.action}`,

--- a/packages/core/src/vite-plugin/web-collections.ts
+++ b/packages/core/src/vite-plugin/web-collections.ts
@@ -2,18 +2,17 @@
  * Manifest → web collection selection (single source of truth).
  *
  * The browser client data runtime (`@happyvertical/smrt-web`, #1761) consumes
- * one typed collection definition per API-exposed REST collection. Three
- * emission sites need the SAME selection and field rules, or the emitted
- * runtime values and their declared types drift apart:
+ * one typed collection definition per API-exposed REST collection. Four
+ * co-managed emission surfaces need the SAME selection and field rules, or the
+ * emitted runtime values and their declared types drift apart:
  *
  *  - the `\0smrt:web` runtime virtual module (JSON literal — {@link generateWebModule})
  *  - the `@happyvertical/smrt-virt-web` ambient d.ts (vite-plugin)
  *  - the physical `@smrt/web` d.ts (prebuild, for `tsc`-only consumers)
+ *  - the dependency-free type mirror in `@happyvertical/smrt-web`
  *
- * All three import {@link selectWebCollectionEntries} from here so the value
- * emission and the type emission can never disagree. A fourth, hand-written
- * mirror of the field/collection definition types lives in
- * `@happyvertical/smrt-web` (`packages/smrt-web/src/index.ts`) — that package
+ * The three generated sites import {@link selectWebCollectionEntries} from
+ * here so the value emission and the type emission can never disagree. The hand-written mirror
  * is deliberately smrt-dependency-free, so its copy cannot import these types;
  * keep it textually in sync when the shape here changes. The per-collection SHAPE
  * (name/objectRef/className/endpoint/idField/actions/fields/relationships) is built by the
@@ -33,6 +32,8 @@ import {
   isCrudAction,
   type ToolDescriptor,
   type ToolFieldMeta,
+  type ToolIdType,
+  type ToolRouteDescriptor,
 } from '../generators/tool-schema.js';
 import type {
   FieldDefinition,
@@ -131,6 +132,40 @@ export interface WebCollectionEntry {
   obj: SmartObjectDefinition;
   /** Sorted set of exposed CRUD + custom actions. */
   actions: string[];
+}
+
+/**
+ * One canonical WebMCP tool candidate. `obj` owns the REST collection and row
+ * contract; `actionHost` declares the action. They differ for custom methods
+ * declared on a `SmrtCollection` subclass.
+ */
+export interface WebMcpToolEntry {
+  collection: string;
+  obj: SmartObjectDefinition;
+  actionHost: SmartObjectDefinition;
+  action: string;
+}
+
+/**
+ * Transport-complete, data-only definition for one generated browser tool.
+ * Unlike {@link WebCollectionEntry}, this shape does not imply that a list
+ * route or cache-backed browser collection exists.
+ */
+export interface WebMcpToolDefinition extends ToolDescriptor {
+  /** Stable definition identity is `(collection, action)`. */
+  collection: string;
+  /** Canonical qualified identity of the row model owning the collection. */
+  objectRef: string;
+  /** Row-model class used by the shared MCP tool vocabulary. */
+  className: string;
+  /** Path below the generated API base path. */
+  endpoint: string;
+  idField: string;
+  idType: ToolIdType;
+  /** Always present so a fetch-only registrar needs no action heuristics. */
+  route: ToolRouteDescriptor;
+  /** Cache-invalidation edges for materialized sibling collections. */
+  relationships: WebRelationship[];
 }
 
 function compareText(left: string, right: string): number {
@@ -526,6 +561,135 @@ export function selectWebCollectionEntries(
   return selectEntriesQualifiedBy(manifest, (actions) => actions.has('list'));
 }
 
+/** Walk to the highest STI ancestor that owns the same REST collection. */
+function resolveStiCollectionOwner(
+  manifest: SmartObjectManifest,
+  obj: SmartObjectDefinition,
+): SmartObjectDefinition {
+  const seen = new Set<string>();
+  let owner = obj;
+  let parentName = owner.extendsQualified || owner.extends;
+  while (parentName && !seen.has(parentName)) {
+    seen.add(parentName);
+    const parent = findManifestObjectByName(manifest, parentName, owner);
+    if (!parent || parent.collection !== obj.collection) break;
+    owner = parent;
+    parentName = owner.extendsQualified || owner.extends;
+  }
+  return owner;
+}
+
+/**
+ * Select every generated WebMCP action independently of collection
+ * materialization. Object actions establish the owning row model first;
+ * collection-class actions then supplement missing `(collection, action)`
+ * identities. Therefore an object action wins an exact collision, while all
+ * ordering is independent of manifest insertion order.
+ */
+export function selectWebMcpToolEntries(
+  manifest: SmartObjectManifest,
+): WebMcpToolEntry[] {
+  const sortedObjects = Object.values(manifest.objects).sort((left, right) =>
+    compareText(
+      webCollectionObjectRef(manifest, left),
+      webCollectionObjectRef(manifest, right),
+    ),
+  );
+  const objectOwners = new Map<string, WebCollectionEntry>();
+
+  for (const candidate of sortedObjects) {
+    if (isCollectionManifestClass(manifest, candidate)) continue;
+    const existing = objectOwners.get(candidate.collection);
+    const candidateIsChild = isStiChildModel(manifest, candidate);
+    const existingIsChild = existing
+      ? isStiChildModel(manifest, existing.obj)
+      : false;
+    if (existing && !(existingIsChild && !candidateIsChild)) continue;
+
+    objectOwners.set(candidate.collection, {
+      collection: candidate.collection,
+      obj: candidate,
+      actions: [],
+    });
+  }
+
+  const entries = new Map<string, WebMcpToolEntry>();
+  const ownerObjects = [...objectOwners.values()]
+    .sort(
+      (left, right) =>
+        compareText(left.collection, right.collection) ||
+        compareText(
+          webCollectionObjectRef(manifest, left.obj),
+          webCollectionObjectRef(manifest, right.obj),
+        ),
+    )
+    .map((entry) => entry.obj);
+  const ownerSet = new Set(ownerObjects);
+  // Owners go first so the STI base wins an exact object-action collision.
+  // Remaining models still contribute unique custom actions on the shared
+  // collection instead of disappearing behind the owning row definition.
+  const objectActionHosts = [
+    ...ownerObjects,
+    ...sortedObjects.filter(
+      (candidate) =>
+        !isCollectionManifestClass(manifest, candidate) &&
+        !ownerSet.has(candidate),
+    ),
+  ];
+
+  for (const actionHost of objectActionHosts) {
+    const owner = objectOwners.get(actionHost.collection);
+    if (!owner) continue;
+    for (const action of [...resolveApiActionSet(actionHost, manifest)].sort(
+      compareText,
+    )) {
+      const identity = `${owner.collection}\0${action}`;
+      if (entries.has(identity)) continue;
+      entries.set(identity, {
+        collection: owner.collection,
+        obj: owner.obj,
+        // CRUD is a shared collection identity owned by the STI base even if
+        // a child is the manifest entry that exposed it. Custom actions retain
+        // their declaring host so route overrides and parameters stay exact.
+        actionHost: isCrudAction(action) ? owner.obj : actionHost,
+        action,
+      });
+    }
+  }
+
+  for (const collectionClass of sortedObjects) {
+    if (!isCollectionManifestClass(manifest, collectionClass)) continue;
+    const itemObject = resolveCollectionItemObject(manifest, collectionClass);
+    if (!itemObject) continue;
+    const owner =
+      objectOwners.get(collectionClass.collection)?.obj ??
+      resolveStiCollectionOwner(manifest, itemObject);
+
+    for (const action of [
+      ...resolveApiActionSet(collectionClass, manifest),
+    ].sort(compareText)) {
+      const identity = `${collectionClass.collection}\0${action}`;
+      if (entries.has(identity)) continue;
+      entries.set(identity, {
+        collection: collectionClass.collection,
+        obj: owner,
+        actionHost: collectionClass,
+        action,
+      });
+    }
+  }
+
+  return [...entries.values()].sort(
+    (left, right) =>
+      compareText(left.collection, right.collection) ||
+      compareText(left.action, right.action) ||
+      compareText(
+        webCollectionObjectRef(manifest, left.actionHost),
+        webCollectionObjectRef(manifest, right.actionHost),
+      ),
+  );
+}
+
 /**
  * Select the entries the ETag salt (#1764) must cover: every api-exposed model
  * with a GENERATED READ ROUTE — `list` OR `get`. Broader than
@@ -735,7 +899,23 @@ export function buildWebToolDescriptors(
   entry: WebCollectionEntry,
   options: { kebabRoutes?: boolean } = {},
 ): ToolDescriptor[] {
-  const webFields = buildWebFieldDefinitions(entry.obj);
+  return buildWebToolDescriptorsForHost({
+    owner: entry.obj,
+    actionHost: entry.obj,
+    actions: entry.actions,
+    options,
+  });
+}
+
+function buildWebToolDescriptorsForHost(input: {
+  owner: SmartObjectDefinition;
+  actionHost: SmartObjectDefinition;
+  actions: string[];
+  options: { kebabRoutes?: boolean };
+  collectionHost?: boolean;
+}): ToolDescriptor[] {
+  const { owner, actionHost, actions, options, collectionHost = false } = input;
+  const webFields = buildWebFieldDefinitions(owner);
   const fields: ToolFieldMeta[] = Object.entries(webFields).map(
     ([name, def]) => ({
       name,
@@ -752,35 +932,38 @@ export function buildWebToolDescriptors(
     }),
   );
   const descriptors = buildToolDescriptors({
-    className: entry.obj.className,
+    className: owner.className,
     fields,
-    actions: entry.actions,
+    actions,
     customActions: Object.fromEntries(
-      entry.actions.map((action) => [
+      actions.map((action) => [
         action,
         resolveCustomActionMetadata({
           actionName: action,
-          method: entry.obj.methods?.[action],
-          apiConfig: entry.obj.decoratorConfig?.api,
+          method: actionHost.methods?.[action],
+          apiConfig: actionHost.decoratorConfig?.api,
+          ...(collectionHost ? { defaultScope: 'collection' as const } : {}),
         }),
       ]),
     ),
-    idType: entry.obj.decoratorConfig.idType,
+    idType: owner.decoratorConfig.idType,
   });
 
   return descriptors.map((descriptor) => {
     if (isCrudAction(descriptor.action)) return descriptor;
-    const method = entry.obj.methods?.[descriptor.action];
+    const method = actionHost.methods?.[descriptor.action];
     const route = resolveApiActionRouteConfig(
       descriptor.action,
       method ?? {},
-      entry.obj.decoratorConfig?.api,
+      actionHost.decoratorConfig?.api,
       { kebabRoutes: options.kebabRoutes },
+      collectionHost ? 'collection' : method?.isStatic ? 'collection' : 'item',
     );
     const metadata = resolveCustomActionMetadata({
       actionName: descriptor.action,
       method,
-      apiConfig: entry.obj.decoratorConfig?.api,
+      apiConfig: actionHost.decoratorConfig?.api,
+      ...(collectionHost ? { defaultScope: 'collection' as const } : {}),
     });
     const parameterAliases = Object.fromEntries(
       (method?.parameters ?? [])
@@ -807,6 +990,65 @@ export function buildWebToolDescriptors(
       },
     };
   });
+}
+
+function crudToolRoute(action: string): ToolRouteDescriptor {
+  switch (action) {
+    case 'list':
+      return { method: 'GET', scope: 'collection', path: [] };
+    case 'get':
+      return { method: 'GET', scope: 'item', path: [] };
+    case 'create':
+      return { method: 'POST', scope: 'collection', path: [] };
+    case 'update':
+      return { method: 'PUT', scope: 'item', path: [] };
+    case 'delete':
+      return { method: 'DELETE', scope: 'item', path: [] };
+    default:
+      throw new Error(`[smrt] Unknown generated CRUD action: ${action}`);
+  }
+}
+
+/** Build the canonical, transport-complete definition for one selected tool. */
+export function buildWebMcpToolDefinition(
+  entry: WebMcpToolEntry,
+  manifest: SmartObjectManifest,
+  options: { kebabRoutes?: boolean } = {},
+): WebMcpToolDefinition {
+  const descriptor = buildWebToolDescriptorsForHost({
+    owner: entry.obj,
+    actionHost: entry.actionHost,
+    actions: [entry.action],
+    options,
+    collectionHost: isCollectionManifestClass(manifest, entry.actionHost),
+  })[0];
+  if (!descriptor) {
+    throw new Error(
+      `[smrt] Failed to build WebMCP descriptor for ${entry.collection}.${entry.action}`,
+    );
+  }
+
+  return {
+    collection: entry.collection,
+    objectRef: webCollectionObjectRef(manifest, entry.obj),
+    className: entry.obj.className,
+    endpoint: `/${entry.collection}`,
+    idField: 'id',
+    idType: entry.obj.decoratorConfig.idType ?? 'uuid',
+    relationships: buildWebRelationships(entry.obj, manifest),
+    ...descriptor,
+    route: descriptor.route ?? crudToolRoute(entry.action),
+  };
+}
+
+/** Emit every API-backed WebMCP tool, including non-list models. */
+export function buildWebMcpToolDefinitions(
+  manifest: SmartObjectManifest,
+  options: { kebabRoutes?: boolean } = {},
+): WebMcpToolDefinition[] {
+  return selectWebMcpToolEntries(manifest).map((entry) =>
+    buildWebMcpToolDefinition(entry, manifest, options),
+  );
 }
 
 /**

--- a/packages/core/src/vite-plugin/web-module.test.ts
+++ b/packages/core/src/vite-plugin/web-module.test.ts
@@ -74,8 +74,10 @@ export class Category extends SmrtObject {
   label: string = '';
 }
 
+@smrt({ api: { include: ['archiveAll'] } })
 export class WidgetCollection extends SmrtCollection<Widget> {
   static readonly _itemClass = Widget;
+  static async archiveAll(options?: { reason?: string }): Promise<void> {}
 }
 
 // Transitive collection subclass: no type argument of its own — must still
@@ -85,6 +87,11 @@ export class SpecialWidgetCollection extends WidgetCollection {}
 @smrt({ api: false })
 export class HiddenGadget extends SmrtObject {
   label: string = '';
+}
+
+@smrt({ api: { include: ['get'] } })
+export class Lookup extends SmrtObject {
+  key: string = '';
 }
 `,
     );
@@ -158,6 +165,32 @@ export class HiddenGadget extends SmrtObject {
     );
   });
 
+  it('emits canonical tools independently of list materialization', async () => {
+    const code = (await load('\0smrt:web')) as string;
+    const tools = extractWebMcpToolDefinitions(code);
+
+    expect(tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          collection: 'lookups',
+          action: 'get',
+          name: 'lookup_get',
+          route: { method: 'GET', scope: 'item', path: [] },
+        }),
+        expect.objectContaining({
+          collection: 'widgets',
+          action: 'archiveAll',
+          name: 'widget_archiveall',
+          route: expect.objectContaining({
+            method: 'POST',
+            scope: 'collection',
+          }),
+        }),
+      ]),
+    );
+    expect(extractDefinitions(code)).not.toHaveProperty('lookups');
+  });
+
   it('emits the build-time manifestHash constant (#1764)', async () => {
     const code = (await load('\0smrt:web')) as string;
     // The runtime module exports a stable, short base64url shape digest. This is
@@ -222,4 +255,17 @@ function extractDefinitions(code: string): Record<string, unknown> {
     throw new Error('collectionDefinitions literal not found in emitted code');
   }
   return JSON.parse(match[1]) as Record<string, unknown>;
+}
+
+/** Parse the canonical `webMcpToolDefinitions` array literal. */
+function extractWebMcpToolDefinitions(
+  code: string,
+): Array<Record<string, unknown>> {
+  const match = code.match(
+    /export const webMcpToolDefinitions = (\[[\s\S]*?\n\]);/,
+  );
+  if (!match) {
+    throw new Error('webMcpToolDefinitions literal not found in emitted code');
+  }
+  return JSON.parse(match[1]) as Array<Record<string, unknown>>;
 }

--- a/packages/smrt-web/AGENTS.md
+++ b/packages/smrt-web/AGENTS.md
@@ -61,6 +61,11 @@ module you are editing. This file keeps what holds in every module.
 
 ## Conventions
 
+- **WebMCP definition mirror** — `WebMcpToolDefinition` textually mirrors the
+  generated `@happyvertical/smrt-virt-web` / physical `@smrt/web` declaration.
+  It is transport-complete and does not imply that a list-materialized client
+  collection exists. Keep the mirror dependency-free.
+
 - **No inter-smrt dependencies** — depends only on TanStack packages
   (dependency-DAG guardrails). Definitions and fetchers arrive as arguments.
 - **Data-query mirror** — `data-query.ts` mirrors the portable

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -270,6 +270,27 @@ export interface SmrtWebToolRouteDescriptor {
   optionsBag?: boolean;
 }
 
+/**
+ * Canonical data-only definition for one API-backed browser tool. Unlike a
+ * collection definition, this does not imply that a list route or client cache
+ * exists.
+ */
+export interface WebMcpToolDefinition extends WebToolDescriptor {
+  /** Stable definition identity is `(collection, action)`. */
+  collection: string;
+  /** Canonical qualified row-model identity. */
+  objectRef: string;
+  /** Row-model class used by the shared MCP tool vocabulary. */
+  className: string;
+  endpoint: string;
+  idField: string;
+  idType: 'uuid' | 'text';
+  /** Complete generated route metadata, including CRUD actions. */
+  route: SmrtWebToolRouteDescriptor;
+  /** Cache-invalidation edges for materialized sibling collections. */
+  relationships: SmrtWebRelationship[];
+}
+
 /** Reserved GET query marker for preserving an options bag's nullish value. */
 const CUSTOM_OPTIONS_QUERY_MARKER = '__smrt_options';
 


### PR DESCRIPTION
## Summary

- emit a canonical `webMcpToolDefinitions` virtual-module export for every API-exposed action, independent of list materialization
- include complete CRUD/custom route metadata and reuse the shared MCP schema builder
- merge collection-class and STI actions deterministically while preserving the existing `collectionDefinitions` and manifest-hash contracts
- keep runtime, ambient, physical, and dependency-free declaration surfaces aligned
- require alias-aware dynamic route inputs in emitted schemas and match collection-action ownership to the live SvelteKit route generator

## Validation

- `pnpm exec vitest run packages/core/src/vite-plugin/web-collections.test.ts packages/core/src/vite-plugin/web-module.test.ts packages/core/src/prebuild/index.test.ts` (78 passed)
- `pnpm --filter @happyvertical/smrt-core test` (4,030 passed; 113 optional skipped)
- `pnpm --filter @happyvertical/smrt-core typecheck`
- `pnpm --filter @happyvertical/smrt-web typecheck`
- `pnpm build` (64 tasks passed)
- pre-commit and pre-push policy, formatting, knowledge, dependency, and workflow checks
- review-cycle: `claude-haiku` preliminary CLEAN; `codex-terra` final CLEAN on `f32cfa9ea6db0453c0b4138e8a096aea7b3a24a0`

Closes #2518

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-webmcp-2518-reviewfix-20260826",
  "issue": 2518,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "focused generator/type-contract tests: 78 passed",
    "@happyvertical/smrt-core tests: 4030 passed",
    "@happyvertical/smrt-core typecheck",
    "@happyvertical/smrt-web typecheck",
    "root build: 64 tasks passed",
    "review-cycle: claude-haiku preliminary CLEAN; codex-terra final CLEAN"
  ]
}
```
