### PR TITLE
feat(smrt-web): execute canonical WebMCP tools

### DIFF
--- a/packages/core/src/generators/rest-custom-actions.spec.ts
+++ b/packages/core/src/generators/rest-custom-actions.spec.ts
@@ -24,10 +24,20 @@ import { APIGenerator } from './rest';
 @smrt({
   api: {
     public: true,
-    include: ['create', 'list', 'get', 'quote', 'inspect', 'ping', 'refuse'],
+    include: [
+      'create',
+      'list',
+      'get',
+      'quote',
+      'inspect',
+      'reserved',
+      'ping',
+      'refuse',
+    ],
     routes: {
       quote: { method: 'POST', path: 'quote' },
       inspect: { method: 'GET', path: 'inspect' },
+      reserved: { method: 'GET', path: 'reserved' },
       ping: { method: 'POST', path: 'ping' },
       refuse: { method: 'POST', path: 'refuse' },
     },
@@ -40,6 +50,13 @@ class ActionWidget extends SmrtObject {
   constructor(options: any = {}) {
     super(options);
     if (options.name !== undefined) this.name = options.name;
+  }
+
+  static reserved(
+    __smrt_options: string,
+    query: string,
+  ): { marker: string; query: string } {
+    return { marker: __smrt_options, query };
   }
 }
 
@@ -78,6 +95,17 @@ class ActionWidgetCollection extends SmrtCollection<ActionWidget> {
 
 describe('runtime REST custom collection actions (#2047)', () => {
   ObjectRegistry.registerCollection('ActionWidget', ActionWidgetCollection);
+  ObjectRegistry.getMethods('ActionWidget').set('reserved', {
+    name: 'reserved',
+    async: false,
+    isPublic: true,
+    isStatic: true,
+    returnType: 'object',
+    parameters: [
+      { name: '__smrt_options', type: 'string', optional: false },
+      { name: 'query', type: 'string', optional: false },
+    ],
+  });
 
   let db: any;
   let handler: (req: Request) => Promise<Response>;
@@ -156,6 +184,20 @@ describe('runtime REST custom collection actions (#2047)', () => {
     expect(
       ((await object.json()) as { result: { value: string } }).result,
     ).toEqual({ value: 'HV' });
+  });
+
+  it('preserves a legitimate positional __smrt_options GET argument', async () => {
+    const response = await get(
+      'reserved?__smrt_options=legitimate&query=widgets',
+    );
+    expect(response.status).toBe(200);
+    expect(
+      (
+        (await response.json()) as {
+          result: { marker: string; query: string };
+        }
+      ).result,
+    ).toEqual({ marker: 'legitimate', query: 'widgets' });
   });
 
   it('maps a returned failure to its status and redacts the payload', async () => {

--- a/packages/core/src/generators/rest.ts
+++ b/packages/core/src/generators/rest.ts
@@ -849,19 +849,27 @@ export class APIGenerator {
       // write. GET reads the query string instead.
       let options: unknown;
       if (routeMethod === 'GET') {
-        const optionsMarker = url.searchParams.get('__smrt_options');
-        if (optionsMarker === 'undefined') {
-          options = undefined;
-        } else if (optionsMarker === 'null') {
-          options = null;
-        } else if (optionsMarker === 'object') {
-          options = {};
+        const isOptionsBag =
+          metadata.parameters === undefined ||
+          (metadata.parameters.length === 1 &&
+            metadata.parameters[0]?.name === 'options');
+        if (isOptionsBag) {
+          const optionsMarker = url.searchParams.get('__smrt_options');
+          if (optionsMarker === 'undefined') {
+            options = undefined;
+          } else if (optionsMarker === 'null') {
+            options = null;
+          } else if (optionsMarker === 'object') {
+            options = {};
+          } else {
+            const entries = [...url.searchParams.entries()].filter(
+              ([key]) => key !== '__smrt_options',
+            );
+            options =
+              entries.length > 0 ? Object.fromEntries(entries) : undefined;
+          }
         } else {
-          const entries = [...url.searchParams.entries()].filter(
-            ([key]) => key !== '__smrt_options',
-          );
-          options =
-            entries.length > 0 ? Object.fromEntries(entries) : undefined;
+          options = Object.fromEntries(url.searchParams.entries());
         }
       } else {
         let rawBody = '';

--- a/packages/core/src/vite-plugin/sveltekit-generator.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.test.ts
@@ -1121,7 +1121,8 @@ describe('SvelteKit Route Generator', () => {
       );
       expect(content).toContain('const pathParams = {');
       expect(content).toContain('profileKey: params.profileKey,');
-      expect(content).toContain(
+      expect(content).toContain("([key]) => key !== '__smrt_options',");
+      expect(content).not.toContain(
         '...Object.fromEntries(new URL(request.url).searchParams.entries()),',
       );
       expect(content).toContain('...pathParams,');

--- a/packages/core/src/vite-plugin/sveltekit-generator.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.test.ts
@@ -949,15 +949,30 @@ describe('SvelteKit Route Generator', () => {
                 isStatic: true,
                 isPublic: true,
               },
+              searchFacts: {
+                name: 'searchFacts',
+                parameters: [
+                  { name: 'query', type: 'string' },
+                  { name: 'limit', type: 'number' },
+                ],
+                returnType: 'Promise<any>',
+                isStatic: true,
+                isPublic: true,
+              },
             },
             decoratorConfig: {
               api: {
-                include: ['browseFacts'],
+                include: ['browseFacts', 'searchFacts'],
                 routes: {
                   browseFacts: {
                     scope: 'collection',
                     method: 'GET',
                     path: 'facts',
+                  },
+                  searchFacts: {
+                    scope: 'collection',
+                    method: 'GET',
+                    path: 'search-facts',
                   },
                 },
               },
@@ -995,6 +1010,18 @@ describe('SvelteKit Route Generator', () => {
       expect(content).toContain("ObjectRegistry.getClass('Document')");
       expect(content).toContain('await ClassRef.browseFacts(options)');
       expect(content).not.toContain('params.id');
+
+      const searchFactsRoute = vi
+        .mocked(writeFileSync)
+        .mock.calls.find((call) =>
+          call[0].toString().includes('documents/search-facts/+server.ts'),
+        );
+      expect(searchFactsRoute).toBeDefined();
+      const searchContent = searchFactsRoute?.[1] as string;
+      expect(searchContent).toContain("([key]) => key !== '__smrt_options',");
+      expect(searchContent).toContain(
+        'await ClassRef.searchFacts(options.query, options.limit)',
+      );
     });
 
     it('emits generated route handlers without explicit any (#1656)', async () => {

--- a/packages/core/src/vite-plugin/sveltekit-generator.test.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.test.ts
@@ -959,10 +959,20 @@ describe('SvelteKit Route Generator', () => {
                 isStatic: true,
                 isPublic: true,
               },
+              searchReserved: {
+                name: 'searchReserved',
+                parameters: [
+                  { name: '__smrt_options', type: 'string' },
+                  { name: 'query', type: 'string' },
+                ],
+                returnType: 'Promise<any>',
+                isStatic: true,
+                isPublic: true,
+              },
             },
             decoratorConfig: {
               api: {
-                include: ['browseFacts', 'searchFacts'],
+                include: ['browseFacts', 'searchFacts', 'searchReserved'],
                 routes: {
                   browseFacts: {
                     scope: 'collection',
@@ -973,6 +983,11 @@ describe('SvelteKit Route Generator', () => {
                     scope: 'collection',
                     method: 'GET',
                     path: 'search-facts',
+                  },
+                  searchReserved: {
+                    scope: 'collection',
+                    method: 'GET',
+                    path: 'search-reserved',
                   },
                 },
               },
@@ -1018,9 +1033,25 @@ describe('SvelteKit Route Generator', () => {
         );
       expect(searchFactsRoute).toBeDefined();
       const searchContent = searchFactsRoute?.[1] as string;
-      expect(searchContent).toContain("([key]) => key !== '__smrt_options',");
+      expect(searchContent).toContain(
+        'new URL(request.url).searchParams.entries(),',
+      );
       expect(searchContent).toContain(
         'await ClassRef.searchFacts(options.query, options.limit)',
+      );
+
+      const reservedRoute = vi
+        .mocked(writeFileSync)
+        .mock.calls.find((call) =>
+          call[0].toString().includes('documents/search-reserved/+server.ts'),
+        );
+      expect(reservedRoute).toBeDefined();
+      const reservedContent = reservedRoute?.[1] as string;
+      expect(reservedContent).toContain(
+        'new URL(request.url).searchParams.entries(),',
+      );
+      expect(reservedContent).toContain(
+        'await ClassRef.searchReserved(options.__smrt_options, options.query)',
       );
     });
 
@@ -1148,8 +1179,7 @@ describe('SvelteKit Route Generator', () => {
       );
       expect(content).toContain('const pathParams = {');
       expect(content).toContain('profileKey: params.profileKey,');
-      expect(content).toContain("([key]) => key !== '__smrt_options',");
-      expect(content).not.toContain(
+      expect(content).toContain(
         '...Object.fromEntries(new URL(request.url).searchParams.entries()),',
       );
       expect(content).toContain('...pathParams,');

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -1124,8 +1124,13 @@ function buildActionOptionsLoad(
     if (hasPathParams) {
       lines.push(
         `  const pathParams = ${pathParamsObjectLiteral};`,
+        '  const searchParams = new URL(request.url).searchParams;',
         '  const options = {',
-        '    ...Object.fromEntries(new URL(request.url).searchParams.entries()),',
+        '    ...Object.fromEntries(',
+        '      [...searchParams.entries()].filter(',
+        "        ([key]) => key !== '__smrt_options',",
+        '      ),',
+        '    ),',
         '    ...pathParams,',
         `  } as ${isSingleOptionsParameter ? 'ActionArgs[0]' : 'ActionOptions'};`,
         '',

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -1124,13 +1124,8 @@ function buildActionOptionsLoad(
     if (hasPathParams) {
       lines.push(
         `  const pathParams = ${pathParamsObjectLiteral};`,
-        '  const searchParams = new URL(request.url).searchParams;',
         '  const options = {',
-        '    ...Object.fromEntries(',
-        '      [...searchParams.entries()].filter(',
-        "        ([key]) => key !== '__smrt_options',",
-        '      ),',
-        '    ),',
+        '    ...Object.fromEntries(new URL(request.url).searchParams.entries()),',
         '    ...pathParams,',
         `  } as ${isSingleOptionsParameter ? 'ActionArgs[0]' : 'ActionOptions'};`,
         '',
@@ -1157,11 +1152,8 @@ function buildActionOptionsLoad(
               '  ) as ActionArgs[0];',
             ]
           : [
-              '  const searchParams = new URL(request.url).searchParams;',
               '  const options = Object.fromEntries(',
-              '    [...searchParams.entries()].filter(',
-              "      ([key]) => key !== '__smrt_options',",
-              '    ),',
+              '    new URL(request.url).searchParams.entries(),',
               '  ) as ActionOptions;',
             ]),
         '',

--- a/packages/core/src/vite-plugin/sveltekit-generator.ts
+++ b/packages/core/src/vite-plugin/sveltekit-generator.ts
@@ -1157,8 +1157,11 @@ function buildActionOptionsLoad(
               '  ) as ActionArgs[0];',
             ]
           : [
+              '  const searchParams = new URL(request.url).searchParams;',
               '  const options = Object.fromEntries(',
-              '    new URL(request.url).searchParams.entries(),',
+              '    [...searchParams.entries()].filter(',
+              "      ([key]) => key !== '__smrt_options',",
+              '    ),',
               '  ) as ActionOptions;',
             ]),
         '',

--- a/packages/core/src/vite-plugin/web-collections.test.ts
+++ b/packages/core/src/vite-plugin/web-collections.test.ts
@@ -588,6 +588,44 @@ describe('canonical WebMCP tool definitions (#2518)', () => {
     });
   });
 
+  it('publishes dynamic route inputs alongside a custom options bag', () => {
+    const product = obj({
+      className: 'Product',
+      collection: 'products',
+      methods: {
+        preview: publicMethod('preview', {
+          parameters: [{ name: 'options', type: 'object', optional: true }],
+        }),
+      },
+      decoratorConfig: {
+        api: {
+          include: ['preview'],
+          routes: {
+            preview: {
+              method: 'GET',
+              path: 'preview/[batchId]',
+            },
+          },
+        },
+      } as SmartObjectDefinition['decoratorConfig'],
+    });
+
+    const [definition] = buildWebMcpToolDefinitions(manifest(product));
+
+    expect(definition?.route).toMatchObject({
+      method: 'GET',
+      path: ['preview', '[batchId]'],
+      optionsBag: true,
+    });
+    expect(definition?.inputSchema).toMatchObject({
+      properties: {
+        options: expect.any(Object),
+        batchId: { type: 'string' },
+      },
+      required: ['id', 'batchId'],
+    });
+  });
+
   it('matches the last emitted collection-class route owner on a shared action', () => {
     const product = obj({
       className: 'Product',

--- a/packages/smrt-web/AGENTS.md
+++ b/packages/smrt-web/AGENTS.md
@@ -38,7 +38,7 @@ module you are editing. This file keeps what holds in every module.
 | `index.ts` hooks + `durable-store.ts` | the six capability hook points, hook error isolation, the no-op guarantee, and the shared durable-store namespacing/wipe registry | [agents/capability-seam.md](agents/capability-seam.md) |
 | `offline/` | durable offline writes — config, sync-apply-only replay, idempotency, the shared namespace-keyed engine, and Web Locks leader election | [agents/offline-outbox.md](agents/offline-outbox.md) |
 | `sse-client.ts` | the client half of live cache invalidation — the app-wide subscriber, the wire contract it consumes, and SSE-vs-polling behaviour | [agents/live-invalidation.md](agents/live-invalidation.md) |
-| `webmcp.ts` | framework-agnostic WebMCP registrar; registers generated collection tools and routes mutations through shared smrt-web cache state | — |
+| `webmcp.ts` | framework-agnostic WebMCP registrar; keeps legacy list-backed tools on collection state and executes canonical tool-only definitions directly through REST fetchers | — |
 | `persistence/` + `update-state.ts` | the read-cache rehydrate capability and the framework-free `updateAvailable` primitive (bundle + contract signals) | [agents/version-persistence.md](agents/version-persistence.md) |
 | `data-query.ts` | dependency-free browser mirror and defensive response normalizer for the canonical bounded data-query envelope (#2444) | — |
 | `remote-query.ts` | query-shaped remote pages over a `SmrtWebCollection`, with keyed stale cache, execution modes, cancellation/latest-query-wins, and optional query-scoped live subscriptions (#2445) | — |
@@ -64,7 +64,12 @@ module you are editing. This file keeps what holds in every module.
 - **WebMCP definition mirror** — `WebMcpToolDefinition` textually mirrors the
   generated `@happyvertical/smrt-virt-web` / physical `@smrt/web` declaration.
   It is transport-complete and does not imply that a list-materialized client
-  collection exists. Keep the mirror dependency-free.
+  collection exists. Keep the mirror dependency-free. Pass canonical tools
+  alongside legacy collection definitions to `registerWebMcpTools`; duplicate
+  names prefer the collection-backed path. Direct mutations invalidate their
+  own and relationship-derived collection names through the public
+  `invalidateSmrtWebCollections()` seam when the host supplies its shared
+  `SmrtWebClient`.
 
 - **No inter-smrt dependencies** — depends only on TanStack packages
   (dependency-DAG guardrails). Definitions and fetchers arrive as arguments.

--- a/packages/smrt-web/AGENTS.md
+++ b/packages/smrt-web/AGENTS.md
@@ -69,7 +69,10 @@ module you are editing. This file keeps what holds in every module.
   names prefer the collection-backed path. Direct mutations invalidate their
   own and relationship-derived collection names through the public
   `invalidateSmrtWebCollections()` seam when the host supplies its shared
-  `SmrtWebClient`.
+  `SmrtWebClient`. Legacy `filter` callbacks receive complete collection
+  metadata; canonical definitions use `filterTool`. Mixing canonical tools with
+  only the legacy filter fails closed rather than fabricating incomplete field
+  metadata for a policy decision.
 
 - **No inter-smrt dependencies** — depends only on TanStack packages
   (dependency-DAG guardrails). Definitions and fetchers arrive as arguments.

--- a/packages/smrt-web/AGENTS.md
+++ b/packages/smrt-web/AGENTS.md
@@ -73,6 +73,11 @@ module you are editing. This file keeps what holds in every module.
   metadata; canonical definitions use `filterTool`. Mixing canonical tools with
   only the legacy filter fails closed rather than fabricating incomplete field
   metadata for a policy decision.
+  Canonical writes validate that shared client handle before registration, and
+  string or structured `{ error }` REST envelopes fail before cache
+  invalidation. The private `__smrt_options` GET sentinel is reserved only for
+  no-path single-options-bag actions; positional actions preserve a legitimate
+  parameter with that name.
 
 - **No inter-smrt dependencies** — depends only on TanStack packages
   (dependency-DAG guardrails). Definitions and fetchers arrive as arguments.

--- a/packages/smrt-web/src/collection.test.ts
+++ b/packages/smrt-web/src/collection.test.ts
@@ -303,6 +303,42 @@ describe('createSmrtCollection', () => {
     await Promise.all([collection.cleanup(), noUpdate.cleanup()]);
   });
 
+  it('rolls back structured delete failures and rejects failed actions', async () => {
+    const failure = {
+      ok: false,
+      code: 'POLICY_LOCKED',
+      message: 'policy locked',
+      status: 403,
+    };
+    const collection = createSmrtCollection(
+      productDefinition('products-structured-failure'),
+      {
+        fetchers: {
+          list: async () => [{ id: 'p1', name: 'Widget' }],
+          create: async (data) => ({ ...data, id: 'p2' }),
+          delete: async () => ({ error: failure }),
+          custom: async () => ({ error: failure }),
+        },
+      },
+    );
+    await collection.preload();
+
+    const transaction = collection.delete('p1');
+    await expect(transaction.isPersisted.promise).rejects.toMatchObject({
+      name: 'SmrtWebRequestError',
+      status: 403,
+      code: 'POLICY_LOCKED',
+    } satisfies Partial<SmrtWebRequestError>);
+    expect(collection.has('p1')).toBe(true);
+    await expect(collection.action('publish', {})).rejects.toMatchObject({
+      name: 'SmrtWebRequestError',
+      status: 403,
+      code: 'POLICY_LOCKED',
+    } satisfies Partial<SmrtWebRequestError>);
+
+    await collection.cleanup();
+  });
+
   it('accepts a shared client handle without leaking the engine', async () => {
     const scripted = makeScriptedFetchers([{ id: 'p1', name: 'Widget' }]);
     const client = createSmrtWebClient();
@@ -652,6 +688,19 @@ describe('payload normalization', () => {
     expect(() => unwrapListResult({ error: 'nope' }, 'products')).toThrow(
       SmrtWebRequestError,
     );
+    expect(() =>
+      unwrapListResult(
+        {
+          error: {
+            ok: false,
+            code: 'FORBIDDEN',
+            message: 'denied',
+            status: 403,
+          },
+        },
+        'products',
+      ),
+    ).toThrow(SmrtWebRequestError);
   });
 
   it('unwraps item payloads and rejects { error } bodies', () => {
@@ -663,6 +712,19 @@ describe('payload normalization', () => {
     );
     expect(() =>
       unwrapItemResult({ error: 'denied' }, 'create(products)'),
+    ).toThrow(SmrtWebRequestError);
+    expect(() =>
+      unwrapItemResult(
+        {
+          error: {
+            ok: false,
+            code: 'INVALID',
+            message: 'bad input',
+            status: 422,
+          },
+        },
+        'create(products)',
+      ),
     ).toThrow(SmrtWebRequestError);
     expect(() => unwrapItemResult(null, 'create(products)')).toThrow(
       SmrtWebRequestError,

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -712,13 +712,15 @@ export function createDefinitionFetchers(
       } else {
         const queryParams = new URLSearchParams();
         if (optionsBag) {
-          if (optionsValue === undefined) {
+          if (optionsValue === undefined && pathArgs.size === 0) {
             queryParams.set(CUSTOM_OPTIONS_QUERY_MARKER, 'undefined');
-          } else if (optionsValue === null) {
+          } else if (optionsValue === null && pathArgs.size === 0) {
             queryParams.set(CUSTOM_OPTIONS_QUERY_MARKER, 'null');
           } else {
             const queryBody =
-              typeof optionsValue === 'object' && !Array.isArray(optionsValue)
+              optionsValue !== null &&
+              typeof optionsValue === 'object' &&
+              !Array.isArray(optionsValue)
                 ? (optionsValue as Record<string, unknown>)
                 : {};
             const entries = Object.entries(queryBody).filter(
@@ -732,7 +734,7 @@ export function createDefinitionFetchers(
                   : String(value),
               );
             }
-            if (entries.length === 0) {
+            if (entries.length === 0 && pathArgs.size === 0) {
               queryParams.set(CUSTOM_OPTIONS_QUERY_MARKER, 'object');
             }
           }

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -436,17 +436,12 @@ export function unwrapListResult(
   result: unknown,
   collectionName: string,
 ): Array<Record<string, unknown>> {
+  throwIfSmrtWebError(result, `list(${collectionName})`);
   if (Array.isArray(result)) {
     return result as Array<Record<string, unknown>>;
   }
   if (result && typeof result === 'object') {
     const record = result as Record<string, unknown>;
-    if (typeof record.error === 'string') {
-      throw new SmrtWebRequestError(
-        `[smrt-web] list(${collectionName}) failed: ${record.error}`,
-        result,
-      );
-    }
     if (Array.isArray(record.data)) {
       return record.data as Array<Record<string, unknown>>;
     }
@@ -466,14 +461,9 @@ export function unwrapItemResult(
   result: unknown,
   context: string,
 ): Record<string, unknown> {
+  throwIfSmrtWebError(result, context);
   if (result && typeof result === 'object' && !Array.isArray(result)) {
     const record = result as Record<string, unknown>;
-    if (typeof record.error === 'string') {
-      throw new SmrtWebRequestError(
-        `[smrt-web] ${context} failed: ${record.error}`,
-        result,
-      );
-    }
     if (
       record.data &&
       typeof record.data === 'object' &&
@@ -486,6 +476,50 @@ export function unwrapItemResult(
   throw new SmrtWebRequestError(
     `[smrt-web] ${context} returned an unexpected payload shape`,
     result,
+  );
+}
+
+/** Reject generated REST error envelopes while preserving opaque successes. */
+export function throwIfSmrtWebError(result: unknown, context: string): unknown {
+  if (!result || typeof result !== 'object' || Array.isArray(result)) {
+    return result;
+  }
+  const error = (result as Record<string, unknown>).error;
+  if (typeof error === 'string') {
+    throw new SmrtWebRequestError(
+      `[smrt-web] ${context} failed: ${error}`,
+      result,
+    );
+  }
+  if (!error || typeof error !== 'object' || Array.isArray(error))
+    return result;
+  const failure = error as Record<string, unknown>;
+  if (
+    failure.ok !== false ||
+    typeof failure.code !== 'string' ||
+    typeof failure.message !== 'string'
+  ) {
+    return result;
+  }
+  const status =
+    typeof failure.status === 'number' &&
+    Number.isInteger(failure.status) &&
+    failure.status >= 400 &&
+    failure.status <= 599
+      ? failure.status
+      : undefined;
+  if (status !== undefined && status >= 500) {
+    throw new SmrtWebRequestError(
+      `[smrt-web] ${context} failed: server error`,
+      undefined,
+      status,
+    );
+  }
+  throw new SmrtWebRequestError(
+    `[smrt-web] ${context} failed: ${failure.message}`,
+    result,
+    status,
+    failure.code,
   );
 }
 
@@ -801,6 +835,8 @@ interface SmrtWebClientEngine extends SmrtWebClient {
   readonly queryClient: QueryClient;
 }
 
+const smrtWebClientHandles = new WeakSet<object>();
+
 /**
  * Create a shared client-cache handle. Pass the returned handle as
  * {@link CreateSmrtCollectionOptions.client} to every collection that should
@@ -811,18 +847,28 @@ export function createSmrtWebClient(): SmrtWebClient {
     __smrtWebClient: 'SmrtWebClient',
     queryClient: new QueryClient(),
   };
+  smrtWebClientHandles.add(engine);
   return engine;
 }
 
 function resolveQueryClient(client?: SmrtWebClient): QueryClient {
   if (!client) return new QueryClient();
   const engine = client as Partial<SmrtWebClientEngine>;
-  if (engine.__smrtWebClient !== 'SmrtWebClient' || !engine.queryClient) {
+  if (
+    !smrtWebClientHandles.has(engine as object) ||
+    engine.__smrtWebClient !== 'SmrtWebClient' ||
+    !engine.queryClient
+  ) {
     throw new SmrtWebRequestError(
       '[smrt-web] options.client must be a handle from createSmrtWebClient()',
     );
   }
   return engine.queryClient;
+}
+
+/** Validate that an opaque cache handle came from {@link createSmrtWebClient}. */
+export function validateSmrtWebClient(client: SmrtWebClient): void {
+  resolveQueryClient(client);
 }
 
 /** Invalidate cached queries whose final key segment names a collection. */
@@ -1462,8 +1508,11 @@ export function createSmrtCollection<TData extends object>(
                 baseUpdatedAt: getBaseUpdatedAt(mutation.original),
               };
               const outcome = await persistMutation(envelope, async () =>
-                // biome-ignore lint/style/noNonNullAssertion: guarded by the surrounding ternary
-                fetchers.delete!(key),
+                throwIfSmrtWebError(
+                  // biome-ignore lint/style/noNonNullAssertion: guarded by the surrounding ternary
+                  await fetchers.delete!(key),
+                  `delete(${definition.name})`,
+                ),
               );
               mutationResults.set(envelope.key, outcome.result);
               anyHandled = anyHandled || outcome.handled;
@@ -1573,6 +1622,7 @@ export function createSmrtCollection<TData extends object>(
         route === undefined
           ? await fetchers.custom(action, args)
           : await fetchers.custom(action, args, route);
+      throwIfSmrtWebError(result, `${action}(${definition.name})`);
       invalidateRelated();
       return result;
     },

--- a/packages/smrt-web/src/index.ts
+++ b/packages/smrt-web/src/index.ts
@@ -552,7 +552,7 @@ export function buildListQuery(params?: Record<string, unknown>): string {
  * failures stay opaque and payload-free.
  */
 export function createDefinitionFetchers(
-  definition: SmrtWebCollectionDefinition<object>,
+  definition: Pick<SmrtWebCollectionDefinition<object>, 'name' | 'endpoint'>,
   basePath = '/api/v1',
   fetchFn: typeof fetch = (...args) => globalThis.fetch(...args),
 ): SmrtCrudFetchers {
@@ -821,6 +821,42 @@ function resolveQueryClient(client?: SmrtWebClient): QueryClient {
     );
   }
   return engine.queryClient;
+}
+
+/** Invalidate cached queries whose final key segment names a collection. */
+function invalidateCollectionQueries(
+  queryClient: QueryClient,
+  collectionNames: ReadonlySet<string>,
+): void {
+  if (collectionNames.size === 0) return;
+  void queryClient.invalidateQueries({
+    predicate: (query) => {
+      const key = query.queryKey;
+      if (!Array.isArray(key) || key.length === 0) return false;
+      const collectionSegment = key[key.length - 1];
+      return (
+        typeof collectionSegment === 'string' &&
+        collectionNames.has(collectionSegment)
+      );
+    },
+  });
+}
+
+/**
+ * Invalidate materialized collection caches through the opaque SMRT client.
+ *
+ * This is the public cache-coherence seam for transports that execute a write
+ * without constructing a {@link SmrtWebCollection} (for example, a tool-only
+ * WebMCP definition). Matching is by collection name across every scope on the
+ * shared client, mirroring settled collection mutations: over-invalidation is
+ * safe, while leaving a related page cache stale is not.
+ */
+export function invalidateSmrtWebCollections(
+  client: SmrtWebClient,
+  collectionNames: readonly string[],
+): void {
+  const queryClient = resolveQueryClient(client);
+  invalidateCollectionQueries(queryClient, new Set(collectionNames));
 }
 
 /**
@@ -1116,17 +1152,7 @@ export function createSmrtCollection<TData extends object>(
    * must not delay the mutation's own settle.
    */
   const invalidateRelated = (): void => {
-    void queryClient.invalidateQueries({
-      predicate: (query) => {
-        const key = query.queryKey;
-        if (!Array.isArray(key) || key.length === 0) return false;
-        const collectionSegment = key[key.length - 1];
-        return (
-          typeof collectionSegment === 'string' &&
-          invalidationTargets.has(collectionSegment)
-        );
-      },
-    });
+    invalidateCollectionQueries(queryClient, invalidationTargets);
   };
 
   // The engine-free context every capability hook receives (#1755). `cacheKey`

--- a/packages/smrt-web/src/webmcp.test.ts
+++ b/packages/smrt-web/src/webmcp.test.ts
@@ -11,7 +11,10 @@ import {
   createSmrtCollection,
   createSmrtWebClient,
 } from './index.js';
-import { registerWebMcpTools } from './webmcp.js';
+import {
+  type RegisterWebMcpToolsOptions,
+  registerWebMcpTools,
+} from './webmcp.js';
 
 // ---------------------------------------------------------------------------
 // A fake WebMCP registry standing in for Chrome's document.modelContext.
@@ -838,6 +841,69 @@ describe('registerWebMcpTools', () => {
       name: 'SmrtWebRequestError',
       message: expect.stringContaining('refresh denied'),
     } satisfies Partial<SmrtWebRequestError>);
+  });
+
+  it('rejects structured canonical failures before cache invalidation', async () => {
+    const registry = installModelContext();
+    const client = createSmrtWebClient();
+    registerWebMcpTools([canonicalTool('refresh', { readOnly: false })], {
+      client,
+      resolveToolFetchers: () => ({
+        custom: async () => ({
+          error: {
+            ok: false,
+            code: 'REFRESH_DENIED',
+            message: 'refresh denied',
+            status: 403,
+          },
+        }),
+      }),
+    });
+
+    await expect(registry.tools[0]?.execute({})).rejects.toMatchObject({
+      name: 'SmrtWebRequestError',
+      message: expect.stringContaining('refresh denied'),
+      status: 403,
+      code: 'REFRESH_DENIED',
+    } satisfies Partial<SmrtWebRequestError>);
+  });
+
+  it('validates a shared client before registering canonical writes', () => {
+    const registry = installModelContext();
+    const invalidClient = {
+      __smrtWebClient: 'SmrtWebClient',
+      queryClient: {},
+    } as SmrtWebClient;
+    const resolver = vi.fn(() => ({ custom: vi.fn() }));
+
+    expect(() =>
+      registerWebMcpTools([canonicalTool('refresh', { readOnly: false })], {
+        client: invalidClient,
+        resolveToolFetchers: resolver,
+      }),
+    ).toThrow('must be a handle from createSmrtWebClient()');
+    expect(resolver).not.toHaveBeenCalled();
+    expect(registry.tools).toEqual([]);
+  });
+
+  it('closes canonical writes over the client validated at registration', async () => {
+    const registry = installModelContext();
+    const registrationOptions: RegisterWebMcpToolsOptions = {
+      client: createSmrtWebClient(),
+      resolveToolFetchers: () => ({ custom: async () => ({ ok: true }) }),
+    };
+    registerWebMcpTools(
+      [canonicalTool('refresh', { readOnly: false })],
+      registrationOptions,
+    );
+
+    registrationOptions.client = {
+      __smrtWebClient: 'SmrtWebClient',
+    } as SmrtWebClient;
+
+    await expect(registry.tools[0]?.execute({})).resolves.toBe(
+      JSON.stringify({ ok: true }),
+    );
   });
 
   it('atomically aborts earlier tools when registration fails', () => {

--- a/packages/smrt-web/src/webmcp.test.ts
+++ b/packages/smrt-web/src/webmcp.test.ts
@@ -682,6 +682,49 @@ describe('registerWebMcpTools', () => {
     ]);
   });
 
+  it('does not leak options-bag markers into GET routes with dynamic path inputs', async () => {
+    const registry = installModelContext();
+    const calls: string[] = [];
+    const fetchFn = (async (url: string | URL) => {
+      calls.push(String(url));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      } as Response;
+    }) as unknown as typeof fetch;
+    registerWebMcpTools(
+      [
+        canonicalTool('preview', {
+          readOnly: false,
+          route: {
+            method: 'GET',
+            scope: 'collection',
+            path: ['preview', '[batchId]'],
+            optionsBag: true,
+          },
+        }),
+      ],
+      { basePath: '/custom-api', fetchFn },
+    );
+
+    const preview = registry.tools[0];
+    await preview?.execute({ batchId: 'b1', options: undefined });
+    await preview?.execute({ batchId: 'b1', options: null });
+    await preview?.execute({ batchId: 'b1', options: {} });
+    await preview?.execute({
+      batchId: 'b1',
+      options: { format: 'summary' },
+    });
+
+    expect(calls).toEqual([
+      '/custom-api/reports/preview/b1',
+      '/custom-api/reports/preview/b1',
+      '/custom-api/reports/preview/b1',
+      '/custom-api/reports/preview/b1?format=summary',
+    ]);
+  });
+
   it('prefers a legacy collection-backed tool when canonical input duplicates its name', async () => {
     const registry = installModelContext();
     const legacyFetchers = mockFetchers();

--- a/packages/smrt-web/src/webmcp.test.ts
+++ b/packages/smrt-web/src/webmcp.test.ts
@@ -1,6 +1,16 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { SmrtCrudFetchers, SmrtWebCollectionDefinition } from './index.js';
-import { buildListQuery } from './index.js';
+import type {
+  SmrtCrudFetchers,
+  SmrtWebCollection,
+  SmrtWebCollectionDefinition,
+  SmrtWebRequestError,
+  WebMcpToolDefinition,
+} from './index.js';
+import {
+  buildListQuery,
+  createSmrtCollection,
+  createSmrtWebClient,
+} from './index.js';
 import { registerWebMcpTools } from './webmcp.js';
 
 // ---------------------------------------------------------------------------
@@ -92,6 +102,41 @@ const MUTATION_DEF: SmrtWebCollectionDefinition = {
     },
   ],
 };
+
+function canonicalTool(
+  action: string,
+  overrides: Partial<WebMcpToolDefinition> = {},
+): WebMcpToolDefinition {
+  const readOnly = action === 'get' || action === 'list';
+  return {
+    collection: 'reports',
+    objectRef: '@test/smrt-web:Report',
+    className: 'Report',
+    endpoint: '/reports',
+    idField: 'id',
+    idType: 'uuid',
+    relationships: [],
+    action,
+    name: `report_${action}`,
+    description: `${action} Report`,
+    inputSchema: { type: 'object', properties: {} },
+    readOnly,
+    route: {
+      method: readOnly ? 'GET' : 'POST',
+      scope: action === 'get' ? 'item' : 'collection',
+      path: action === 'get' || action === 'create' ? [] : [action],
+    },
+    ...overrides,
+  };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let i = 0; i < 50; i += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  if (!predicate()) throw new Error('waitFor: predicate never became true');
+}
 
 function mockFetchers(overrides: Partial<SmrtCrudFetchers> = {}) {
   return {
@@ -476,6 +521,284 @@ describe('registerWebMcpTools', () => {
     const getTool = registry.tools.find((t) => t.name === 'product_get');
     await getTool?.execute({ slug: 'my-widget' });
     expect(fetchers.get).toHaveBeenCalledWith('my-widget');
+  });
+
+  it('executes get-only and custom-action-only canonical tools without collection fetchers', async () => {
+    const registry = installModelContext();
+    const legacyResolver = vi.fn(() => mockFetchers());
+    const get = vi.fn(async (id: string) => ({ data: { id, title: 'One' } }));
+    const custom = vi.fn(
+      async (_action: string, args: Record<string, unknown>) => ({
+        ok: true,
+        args,
+      }),
+    );
+    const directResolver = vi.fn(() => ({ get, custom }));
+
+    registerWebMcpTools(
+      [canonicalTool('get'), canonicalTool('refresh', { readOnly: false })],
+      { resolveFetchers: legacyResolver, resolveToolFetchers: directResolver },
+    );
+
+    const got = await registry.tools
+      .find((tool) => tool.name === 'report_get')
+      ?.execute({ id: 'r1' });
+    const refreshed = await registry.tools
+      .find((tool) => tool.name === 'report_refresh')
+      ?.execute({ force: true });
+
+    expect(legacyResolver).not.toHaveBeenCalled();
+    expect(directResolver).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledWith('r1');
+    expect(JSON.parse(got as string)).toEqual({ id: 'r1', title: 'One' });
+    expect(custom).toHaveBeenCalledWith(
+      'refresh',
+      { force: true },
+      expect.objectContaining({ path: ['refresh'] }),
+    );
+    expect(JSON.parse(refreshed as string)).toEqual({
+      ok: true,
+      args: { force: true },
+    });
+  });
+
+  it('executes canonical CRUD mutations directly and normalizes item envelopes', async () => {
+    const registry = installModelContext();
+    const create = vi.fn(async (data: Record<string, unknown>) => ({
+      data: { id: 'r2', ...data },
+    }));
+    const update = vi.fn(async (id: string, data: Record<string, unknown>) => ({
+      id,
+      ...data,
+    }));
+    const remove = vi.fn(async () => true);
+    registerWebMcpTools(
+      [
+        canonicalTool('create', {
+          route: { method: 'POST', scope: 'collection', path: [] },
+        }),
+        canonicalTool('update', {
+          route: { method: 'PUT', scope: 'item', path: [] },
+        }),
+        canonicalTool('delete', {
+          route: { method: 'DELETE', scope: 'item', path: [] },
+        }),
+      ],
+      {
+        resolveToolFetchers: () => ({ create, update, delete: remove }),
+      },
+    );
+
+    const created = await registry.tools
+      .find((tool) => tool.name === 'report_create')
+      ?.execute({ title: 'Draft' });
+    const updated = await registry.tools
+      .find((tool) => tool.name === 'report_update')
+      ?.execute({ id: 'r2', title: 'Final' });
+    const deleted = await registry.tools
+      .find((tool) => tool.name === 'report_delete')
+      ?.execute({ id: 'r2' });
+
+    expect(create).toHaveBeenCalledWith({ title: 'Draft' });
+    expect(update).toHaveBeenCalledWith('r2', { title: 'Final' });
+    expect(remove).toHaveBeenCalledWith('r2');
+    expect(JSON.parse(created as string)).toEqual({
+      id: 'r2',
+      title: 'Draft',
+    });
+    expect(JSON.parse(updated as string)).toEqual({
+      id: 'r2',
+      title: 'Final',
+    });
+    expect(JSON.parse(deleted as string)).toEqual({
+      success: true,
+      id: 'r2',
+    });
+  });
+
+  it('preserves canonical custom route transport on the default authenticated fetch path', async () => {
+    const registry = installModelContext();
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchFn = (async (url: string | URL, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      } as Response;
+    }) as unknown as typeof fetch;
+    registerWebMcpTools(
+      [
+        canonicalTool('refresh', {
+          readOnly: false,
+          route: {
+            method: 'PATCH',
+            scope: 'item',
+            path: ['refresh-now'],
+          },
+        }),
+      ],
+      { basePath: '/custom-api', fetchFn },
+    );
+
+    await registry.tools[0]?.execute({ id: 'r1', force: true });
+
+    expect(calls).toEqual([
+      {
+        url: '/custom-api/reports/r1/refresh-now',
+        init: expect.objectContaining({
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ force: true }),
+        }),
+      },
+    ]);
+  });
+
+  it('prefers a legacy collection-backed tool when canonical input duplicates its name', async () => {
+    const registry = installModelContext();
+    const legacyFetchers = mockFetchers();
+    const directResolver = vi.fn(() => ({ list: vi.fn() }));
+    registerWebMcpTools(
+      [
+        canonicalTool('list', {
+          collection: 'products',
+          className: 'Product',
+          objectRef: '@test/smrt-web:Product',
+          endpoint: '/products',
+          name: 'product_list',
+        }),
+        PRODUCT_DEF,
+      ],
+      {
+        resolveFetchers: () => legacyFetchers,
+        resolveToolFetchers: directResolver,
+      },
+    );
+
+    expect(
+      registry.tools.filter((tool) => tool.name === 'product_list'),
+    ).toHaveLength(1);
+    await registry.tools
+      .find((tool) => tool.name === 'product_list')
+      ?.execute({ limit: 1 });
+    expect(legacyFetchers.list).toHaveBeenCalledWith({ limit: 1 });
+    expect(directResolver).not.toHaveBeenCalled();
+  });
+
+  it('invalidates only the mutated canonical collection and its relationship targets', async () => {
+    const registry = installModelContext();
+    const client = createSmrtWebClient();
+    const cleanups: Array<SmrtWebCollection<Record<string, unknown>>> = [];
+    const calls = { reports: 0, articles: 0, tags: 0 };
+    const materialize = (name: keyof typeof calls) => {
+      const collection = createSmrtCollection(
+        {
+          name,
+          className: name,
+          endpoint: `/${name}`,
+          idField: 'id',
+          actions: ['list'],
+          fields: {},
+        },
+        {
+          client,
+          staleTimeMs: 60_000,
+          fetchers: {
+            ...mockFetchers(),
+            list: async () => {
+              calls[name] += 1;
+              return [{ id: `${name}-1` }];
+            },
+          },
+        },
+      );
+      cleanups.push(collection);
+      return collection;
+    };
+    const reports = materialize('reports');
+    const articles = materialize('articles');
+    const tags = materialize('tags');
+    const subscriptions = [reports, articles, tags].map((collection) =>
+      collection.subscribeChanges(() => {}),
+    );
+    await Promise.all([reports.preload(), articles.preload(), tags.preload()]);
+
+    registerWebMcpTools(
+      [
+        canonicalTool('refresh', {
+          readOnly: false,
+          relationships: [
+            {
+              field: 'articleId',
+              kind: 'foreignKey',
+              relatedCollection: 'articles',
+            },
+          ],
+        }),
+      ],
+      {
+        client,
+        resolveToolFetchers: () => ({
+          custom: vi.fn(async () => ({ ok: true })),
+        }),
+      },
+    );
+    await registry.tools[0]?.execute({});
+    await waitFor(() => calls.reports >= 2 && calls.articles >= 2);
+
+    expect(calls.reports).toBeGreaterThanOrEqual(2);
+    expect(calls.articles).toBeGreaterThanOrEqual(2);
+    expect(calls.tags).toBe(1);
+    subscriptions.forEach((subscription) => {
+      subscription.unsubscribe();
+    });
+    await Promise.all(cleanups.map((collection) => collection.cleanup()));
+  });
+
+  it('throws SmrtWebRequestError for canonical tool error envelopes', async () => {
+    const registry = installModelContext();
+    registerWebMcpTools([canonicalTool('refresh', { readOnly: false })], {
+      resolveToolFetchers: () => ({
+        custom: async () => ({ error: 'refresh denied' }),
+      }),
+    });
+
+    await expect(registry.tools[0]?.execute({})).rejects.toMatchObject({
+      name: 'SmrtWebRequestError',
+      message: expect.stringContaining('refresh denied'),
+    } satisfies Partial<SmrtWebRequestError>);
+  });
+
+  it('atomically aborts earlier tools when registration fails', () => {
+    const registry = installModelContext();
+    let calls = 0;
+    const documentRef = (
+      globalThis as {
+        document?: { modelContext?: { registerTool?: unknown } };
+      }
+    ).document;
+    if (!documentRef?.modelContext)
+      throw new Error('modelContext not installed');
+    documentRef.modelContext.registerTool = (
+      tool: CapturedTool,
+      opts?: { signal?: AbortSignal },
+    ) => {
+      calls += 1;
+      if (calls === 2) throw new Error('duplicate host tool');
+      registry.tools.push(tool);
+      opts?.signal?.addEventListener('abort', () =>
+        registry.unregistered.push(tool.name),
+      );
+    };
+
+    expect(() =>
+      registerWebMcpTools(
+        [canonicalTool('get'), canonicalTool('refresh', { readOnly: false })],
+        { resolveToolFetchers: () => ({ get: vi.fn(), custom: vi.fn() }) },
+      ),
+    ).toThrow('duplicate host tool');
+    expect(registry.unregistered).toEqual(['report_get']);
   });
 });
 

--- a/packages/smrt-web/src/webmcp.test.ts
+++ b/packages/smrt-web/src/webmcp.test.ts
@@ -285,6 +285,33 @@ describe('registerWebMcpTools', () => {
     expect(registry.tools.map((t) => t.name)).toEqual(['product_list']);
   });
 
+  it('filters canonical definitions through the explicit tool predicate', () => {
+    const registry = installModelContext();
+    registerWebMcpTools(
+      [canonicalTool('get'), canonicalTool('refresh', { readOnly: false })],
+      {
+        resolveToolFetchers: () => ({ get: vi.fn(), custom: vi.fn() }),
+        filterTool: (definition) => definition.readOnly,
+      },
+    );
+    expect(registry.tools.map((tool) => tool.name)).toEqual(['report_get']);
+  });
+
+  it('fails closed when canonical tools have only the legacy collection filter', () => {
+    const registry = installModelContext();
+    expect(() =>
+      registerWebMcpTools(
+        [canonicalTool('get'), canonicalTool('refresh', { readOnly: false })],
+        {
+          resolveToolFetchers: () => ({ get: vi.fn(), custom: vi.fn() }),
+          filter: (_definition, descriptor) => descriptor.readOnly,
+        },
+      ),
+    ).toThrow('require filterTool');
+    expect(registry.unregistered).toEqual([]);
+    expect(registry.tools).toEqual([]);
+  });
+
   it('ignores definitions with no tool descriptors', () => {
     const registry = installModelContext();
     const bare: SmrtWebCollectionDefinition = {
@@ -548,7 +575,7 @@ describe('registerWebMcpTools', () => {
       ?.execute({ force: true });
 
     expect(legacyResolver).not.toHaveBeenCalled();
-    expect(directResolver).toHaveBeenCalledTimes(1);
+    expect(directResolver).toHaveBeenCalledTimes(2);
     expect(get).toHaveBeenCalledWith('r1');
     expect(JSON.parse(got as string)).toEqual({ id: 'r1', title: 'One' });
     expect(custom).toHaveBeenCalledWith(

--- a/packages/smrt-web/src/webmcp.ts
+++ b/packages/smrt-web/src/webmcp.ts
@@ -102,6 +102,8 @@ export interface RegisterWebMcpToolsOptions {
       SmrtWebCollectionDefinition['toolDescriptors']
     >[number],
   ) => boolean;
+  /** Predicate for canonical per-tool definitions. */
+  filterTool?: (definition: WebMcpToolDefinition) => boolean;
 }
 
 /** Accepted legacy collection definitions and canonical per-tool definitions. */
@@ -132,7 +134,6 @@ export function registerWebMcpTools(
     SmrtWebCollection<Record<string, unknown>>
   >();
   const registeredNames = new Set<string>();
-  const directFetchers = new Map<string, Partial<SmrtCrudFetchers>>();
   let disposed = false;
   const dispose = (): void => {
     if (disposed) return;
@@ -198,21 +199,26 @@ export function registerWebMcpTools(
     for (const definition of definitions) {
       if (!isCanonicalToolDefinition(definition)) continue;
       if (registeredNames.has(definition.name)) continue;
-      const filterDefinition = collectionViewOfTool(definition);
-      if (options.filter && !options.filter(filterDefinition, definition)) {
+      // A legacy collection filter may inspect fields that canonical per-tool
+      // definitions deliberately do not carry. Never fabricate incomplete
+      // metadata and risk a fail-open policy decision: hosts mixing canonical
+      // definitions with the legacy filter must provide the explicit tool
+      // predicate as well.
+      if (options.filter && !options.filterTool) {
+        throw new Error(
+          '[smrt-web] canonical WebMCP definitions require filterTool when filter is configured',
+        );
+      }
+      if (options.filterTool && !options.filterTool(definition)) {
         continue;
       }
-      let fetchers = directFetchers.get(definition.collection);
-      if (!fetchers) {
-        fetchers = options.resolveToolFetchers
-          ? options.resolveToolFetchers(definition)
-          : createDefinitionFetchers(
-              { name: definition.collection, endpoint: definition.endpoint },
-              basePath,
-              options.fetchFn,
-            );
-        directFetchers.set(definition.collection, fetchers);
-      }
+      const fetchers = options.resolveToolFetchers
+        ? options.resolveToolFetchers(definition)
+        : createDefinitionFetchers(
+            { name: definition.collection, endpoint: definition.endpoint },
+            basePath,
+            options.fetchFn,
+          );
       ctx.registerTool(
         {
           name: definition.name,
@@ -240,23 +246,6 @@ function isCanonicalToolDefinition(
   definition: WebMcpRegistrationDefinition,
 ): definition is WebMcpToolDefinition {
   return 'collection' in definition && 'readOnly' in definition;
-}
-
-/** Preserve the legacy filter callback while canonical definitions are additive. */
-function collectionViewOfTool(
-  definition: WebMcpToolDefinition,
-): SmrtWebCollectionDefinition {
-  return {
-    name: definition.collection,
-    objectRef: definition.objectRef,
-    className: definition.className,
-    endpoint: definition.endpoint,
-    idField: definition.idField,
-    actions: [definition.action],
-    toolDescriptors: [definition],
-    fields: {},
-    relationships: definition.relationships,
-  };
 }
 
 /** Require and return a string `id` from tool args, or throw a clear error. */

--- a/packages/smrt-web/src/webmcp.ts
+++ b/packages/smrt-web/src/webmcp.ts
@@ -25,10 +25,11 @@ import {
   type SmrtWebClient,
   type SmrtWebCollection,
   type SmrtWebCollectionDefinition,
-  SmrtWebRequestError,
   type SmrtWebTransaction,
+  throwIfSmrtWebError,
   unwrapItemResult,
   unwrapListResult,
+  validateSmrtWebClient,
   type WebMcpToolDefinition,
   type WebToolDescriptor,
 } from './index.js';
@@ -125,6 +126,7 @@ export function registerWebMcpTools(
   if (!ctx) return () => {};
 
   const basePath = options.basePath ?? '/api/v1';
+  const client = options.client;
   // ONE controller deregisters every tool this call registers: WebMCP removes a
   // tool when the signal it was registered with aborts, so the returned disposer
   // simply aborts. Idempotent — a second call is a harmless no-op.
@@ -134,6 +136,7 @@ export function registerWebMcpTools(
     SmrtWebCollection<Record<string, unknown>>
   >();
   const registeredNames = new Set<string>();
+  let clientValidated = false;
   let disposed = false;
   const dispose = (): void => {
     if (disposed) return;
@@ -168,7 +171,7 @@ export function registerWebMcpTools(
         fetchers,
         basePath,
         fetchFn: options.fetchFn,
-        ...(options.client ? { client: options.client } : {}),
+        ...(client ? { client } : {}),
         ...(options.scope ? { scope: options.scope } : {}),
       }) as SmrtWebCollection<Record<string, unknown>>;
       collections.set(definition, collection);
@@ -212,6 +215,10 @@ export function registerWebMcpTools(
       if (options.filterTool && !options.filterTool(definition)) {
         continue;
       }
+      if (!definition.readOnly && client && !clientValidated) {
+        validateSmrtWebClient(client);
+        clientValidated = true;
+      }
       const fetchers = options.resolveToolFetchers
         ? options.resolveToolFetchers(definition)
         : createDefinitionFetchers(
@@ -226,7 +233,7 @@ export function registerWebMcpTools(
           inputSchema: definition.inputSchema,
           annotations: { readOnlyHint: definition.readOnly },
           execute: (args) =>
-            dispatchDirect(fetchers, definition, args ?? {}, options.client),
+            dispatchDirect(fetchers, definition, args ?? {}, client),
         },
         { signal: controller.signal },
       );
@@ -418,7 +425,7 @@ async function dispatchDirect(
       }
       const id = requireId(args, 'delete');
       const deleteResult = await fetchers.delete(id);
-      throwIfToolError(deleteResult, `delete(${definition.collection})`);
+      throwIfSmrtWebError(deleteResult, `delete(${definition.collection})`);
       result = { success: true, id };
       break;
     }
@@ -428,7 +435,7 @@ async function dispatchDirect(
           `${definition.collection} has no custom action fetcher`,
         );
       }
-      result = throwIfToolError(
+      result = throwIfSmrtWebError(
         await fetchers.custom(definition.action, args, definition.route),
         `${definition.action}(${definition.collection})`,
       );
@@ -443,20 +450,6 @@ async function dispatchDirect(
     ]);
   }
   return JSON.stringify(result);
-}
-
-/** Reject the `{ error: string }` envelope without rewriting successful data. */
-function throwIfToolError(result: unknown, context: string): unknown {
-  if (result && typeof result === 'object' && !Array.isArray(result)) {
-    const error = (result as Record<string, unknown>).error;
-    if (typeof error === 'string') {
-      throw new SmrtWebRequestError(
-        `[smrt-web] ${context} failed: ${error}`,
-        result,
-      );
-    }
-  }
-  return result;
 }
 
 /** Await the shared collection mutation lifecycle and return its server value. */

--- a/packages/smrt-web/src/webmcp.ts
+++ b/packages/smrt-web/src/webmcp.ts
@@ -10,21 +10,26 @@
  * policy #1540) are the security boundary — nothing is re-implemented here.
  *
  * Framework-agnostic: this module imports no UI framework. `document.modelContext`
- * is a browser global, not a dependency. Mutation actions use the same
- * optimistic/invalidation path as page code through `createSmrtCollection`.
+ * is a browser global, not a dependency. Legacy list-backed mutations use the
+ * same optimistic path as page code through `createSmrtCollection`; canonical
+ * tool-only definitions execute through REST fetchers and invalidate any
+ * materialized sibling caches through the host's shared `SmrtWebClient`.
  */
 
 import {
   createDefinitionFetchers,
   createSmrtCollection,
+  invalidateSmrtWebCollections,
   newLocalId,
   type SmrtCrudFetchers,
   type SmrtWebClient,
   type SmrtWebCollection,
   type SmrtWebCollectionDefinition,
+  SmrtWebRequestError,
   type SmrtWebTransaction,
   unwrapItemResult,
   unwrapListResult,
+  type WebMcpToolDefinition,
   type WebToolDescriptor,
 } from './index.js';
 import {
@@ -82,6 +87,14 @@ export interface RegisterWebMcpToolsOptions {
   resolveFetchers?: (
     definition: SmrtWebCollectionDefinition,
   ) => SmrtCrudFetchers;
+  /**
+   * Override direct REST fetchers for a canonical tool-only definition.
+   * Fetchers are optional because a get-only or custom-action-only model does
+   * not have a list or create route.
+   */
+  resolveToolFetchers?: (
+    definition: WebMcpToolDefinition,
+  ) => Partial<SmrtCrudFetchers>;
   /** Predicate to include/exclude individual tools (e.g. reads-only surfaces). */
   filter?: (
     definition: SmrtWebCollectionDefinition,
@@ -91,6 +104,11 @@ export interface RegisterWebMcpToolsOptions {
   ) => boolean;
 }
 
+/** Accepted legacy collection definitions and canonical per-tool definitions. */
+export type WebMcpRegistrationDefinition =
+  | SmrtWebCollectionDefinition
+  | WebMcpToolDefinition;
+
 /**
  * Register every collection's generated tool descriptors with WebMCP.
  *
@@ -98,7 +116,7 @@ export interface RegisterWebMcpToolsOptions {
  * browser without WebMCP the call is a no-op and the disposer is inert.
  */
 export function registerWebMcpTools(
-  definitions: SmrtWebCollectionDefinition[],
+  definitions: readonly WebMcpRegistrationDefinition[],
   options: RegisterWebMcpToolsOptions = {},
 ): () => void {
   const ctx = getModelContext();
@@ -113,48 +131,12 @@ export function registerWebMcpTools(
     SmrtWebCollectionDefinition,
     SmrtWebCollection<Record<string, unknown>>
   >();
-
-  for (const definition of definitions) {
-    const descriptors = definition.toolDescriptors;
-    if (!descriptors || descriptors.length === 0) continue;
-
-    const fetchers = options.resolveFetchers
-      ? options.resolveFetchers(definition)
-      : createDefinitionFetchers(definition, basePath, options.fetchFn);
-    const collection = createSmrtCollection(definition, {
-      fetchers,
-      basePath,
-      fetchFn: options.fetchFn,
-      ...(options.client ? { client: options.client } : {}),
-      ...(options.scope ? { scope: options.scope } : {}),
-    }) as SmrtWebCollection<Record<string, unknown>>;
-    collections.set(definition, collection);
-
-    for (const descriptor of descriptors) {
-      if (options.filter && !options.filter(definition, descriptor)) continue;
-
-      ctx.registerTool(
-        {
-          name: descriptor.name,
-          description: descriptor.description,
-          inputSchema: descriptor.inputSchema,
-          annotations: { readOnlyHint: descriptor.readOnly },
-          execute: (args) =>
-            dispatch(
-              fetchers,
-              collection,
-              definition,
-              descriptor.action,
-              descriptor.route,
-              args ?? {},
-            ),
-        },
-        { signal: controller.signal },
-      );
-    }
-  }
-
-  return () => {
+  const registeredNames = new Set<string>();
+  const directFetchers = new Map<string, Partial<SmrtCrudFetchers>>();
+  let disposed = false;
+  const dispose = (): void => {
+    if (disposed) return;
+    disposed = true;
     controller.abort();
     for (const collection of collections.values()) {
       // Disposal is intentionally synchronous for WebMCP callers, but cleanup
@@ -163,6 +145,117 @@ export function registerWebMcpTools(
       // unhandled promise rejection in the host page.
       void collection.cleanup().catch(() => undefined);
     }
+  };
+
+  try {
+    // Prefer legacy collection-backed definitions regardless of input order.
+    // Their optimistic mutation and cache behavior is the established path;
+    // canonical entries for the same tool name are duplicate transport data.
+    for (const definition of definitions) {
+      if (isCanonicalToolDefinition(definition)) continue;
+      const descriptors = (definition.toolDescriptors ?? []).filter(
+        (descriptor) =>
+          !registeredNames.has(descriptor.name) &&
+          (!options.filter || options.filter(definition, descriptor)),
+      );
+      if (descriptors.length === 0) continue;
+
+      const fetchers = options.resolveFetchers
+        ? options.resolveFetchers(definition)
+        : createDefinitionFetchers(definition, basePath, options.fetchFn);
+      const collection = createSmrtCollection(definition, {
+        fetchers,
+        basePath,
+        fetchFn: options.fetchFn,
+        ...(options.client ? { client: options.client } : {}),
+        ...(options.scope ? { scope: options.scope } : {}),
+      }) as SmrtWebCollection<Record<string, unknown>>;
+      collections.set(definition, collection);
+
+      for (const descriptor of descriptors) {
+        ctx.registerTool(
+          {
+            name: descriptor.name,
+            description: descriptor.description,
+            inputSchema: descriptor.inputSchema,
+            annotations: { readOnlyHint: descriptor.readOnly },
+            execute: (args) =>
+              dispatchCollection(
+                fetchers,
+                collection,
+                definition,
+                descriptor.action,
+                descriptor.route,
+                args ?? {},
+              ),
+          },
+          { signal: controller.signal },
+        );
+        registeredNames.add(descriptor.name);
+      }
+    }
+
+    for (const definition of definitions) {
+      if (!isCanonicalToolDefinition(definition)) continue;
+      if (registeredNames.has(definition.name)) continue;
+      const filterDefinition = collectionViewOfTool(definition);
+      if (options.filter && !options.filter(filterDefinition, definition)) {
+        continue;
+      }
+      let fetchers = directFetchers.get(definition.collection);
+      if (!fetchers) {
+        fetchers = options.resolveToolFetchers
+          ? options.resolveToolFetchers(definition)
+          : createDefinitionFetchers(
+              { name: definition.collection, endpoint: definition.endpoint },
+              basePath,
+              options.fetchFn,
+            );
+        directFetchers.set(definition.collection, fetchers);
+      }
+      ctx.registerTool(
+        {
+          name: definition.name,
+          description: definition.description,
+          inputSchema: definition.inputSchema,
+          annotations: { readOnlyHint: definition.readOnly },
+          execute: (args) =>
+            dispatchDirect(fetchers, definition, args ?? {}, options.client),
+        },
+        { signal: controller.signal },
+      );
+      registeredNames.add(definition.name);
+    }
+  } catch (error) {
+    // Abort removes every tool registered with this call. Collection cleanup is
+    // best-effort async but all handles are detached synchronously first.
+    dispose();
+    throw error;
+  }
+
+  return dispose;
+}
+
+function isCanonicalToolDefinition(
+  definition: WebMcpRegistrationDefinition,
+): definition is WebMcpToolDefinition {
+  return 'collection' in definition && 'readOnly' in definition;
+}
+
+/** Preserve the legacy filter callback while canonical definitions are additive. */
+function collectionViewOfTool(
+  definition: WebMcpToolDefinition,
+): SmrtWebCollectionDefinition {
+  return {
+    name: definition.collection,
+    objectRef: definition.objectRef,
+    className: definition.className,
+    endpoint: definition.endpoint,
+    idField: definition.idField,
+    actions: [definition.action],
+    toolDescriptors: [definition],
+    fields: {},
+    relationships: definition.relationships,
   };
 }
 
@@ -204,7 +297,7 @@ function listParams(args: Record<string, unknown>): Record<string, unknown> {
  * normalization ({@link unwrapListResult} / {@link unwrapItemResult}), so
  * `{ error }` bodies surface as thrown `SmrtWebRequestError`s the agent sees.
  */
-async function dispatch(
+async function dispatchCollection(
   fetchers: SmrtCrudFetchers,
   collection: SmrtWebCollection<Record<string, unknown>>,
   definition: SmrtWebCollectionDefinition,
@@ -280,6 +373,101 @@ async function dispatch(
       }
       return JSON.stringify(await collection.action(action, args, route));
   }
+}
+
+/** Execute a canonical definition without constructing a client collection. */
+async function dispatchDirect(
+  fetchers: Partial<SmrtCrudFetchers>,
+  definition: WebMcpToolDefinition,
+  args: Record<string, unknown>,
+  client?: SmrtWebClient,
+): Promise<string> {
+  let result: unknown;
+  switch (definition.action) {
+    case 'list':
+      if (!fetchers.list) {
+        throw new Error(`${definition.collection} has no list action`);
+      }
+      result = unwrapListResult(
+        await fetchers.list(listParams(args)),
+        definition.collection,
+      );
+      break;
+    case 'get':
+      if (!fetchers.get) {
+        throw new Error(`${definition.collection} has no get action`);
+      }
+      result = unwrapItemResult(
+        await fetchers.get(requireIdentifier(args)),
+        `get(${definition.collection})`,
+      );
+      break;
+    case 'create':
+      if (!fetchers.create) {
+        throw new Error(`${definition.collection} has no create action`);
+      }
+      result = unwrapItemResult(
+        await fetchers.create(args),
+        `create(${definition.collection})`,
+      );
+      break;
+    case 'update': {
+      if (!fetchers.update) {
+        throw new Error(`${definition.collection} has no update action`);
+      }
+      const id = requireId(args, 'update');
+      const { id: _id, ...body } = args;
+      result = unwrapItemResult(
+        await fetchers.update(id, body),
+        `update(${definition.collection})`,
+      );
+      break;
+    }
+    case 'delete': {
+      if (!fetchers.delete) {
+        throw new Error(`${definition.collection} has no delete action`);
+      }
+      const id = requireId(args, 'delete');
+      const deleteResult = await fetchers.delete(id);
+      throwIfToolError(deleteResult, `delete(${definition.collection})`);
+      result = { success: true, id };
+      break;
+    }
+    default:
+      if (!fetchers.custom) {
+        throw new Error(
+          `${definition.collection} has no custom action fetcher`,
+        );
+      }
+      result = throwIfToolError(
+        await fetchers.custom(definition.action, args, definition.route),
+        `${definition.action}(${definition.collection})`,
+      );
+  }
+
+  if (!definition.readOnly && client) {
+    invalidateSmrtWebCollections(client, [
+      definition.collection,
+      ...definition.relationships.map(
+        (relationship) => relationship.relatedCollection,
+      ),
+    ]);
+  }
+  return JSON.stringify(result);
+}
+
+/** Reject the `{ error: string }` envelope without rewriting successful data. */
+function throwIfToolError(result: unknown, context: string): unknown {
+  if (result && typeof result === 'object' && !Array.isArray(result)) {
+    const error = (result as Record<string, unknown>).error;
+    if (typeof error === 'string') {
+      throw new SmrtWebRequestError(
+        `[smrt-web] ${context} failed: ${error}`,
+        result,
+      );
+    }
+  }
+  return result;
 }
 
 /** Await the shared collection mutation lifecycle and return its server value. */


### PR DESCRIPTION
## Summary

- execute canonical tool-only WebMCP definitions directly through generated REST fetchers, without constructing TanStack DB collections or reaching into private engine state
- preserve the existing list-backed runtime, including deterministic legacy precedence for duplicate names and fail-closed canonical filtering when only the legacy filter is configured
- normalize direct and collection-backed failures consistently, validate and snapshot the public client handle before registration, and invalidate owning/related shared caches only after successful direct mutations
- preserve generated custom-action transport shapes, including legitimate positional `__smrt_options` values and private marker suppression for true options-bag routes

Closes #2519

## Validation

- focused core transport/generator tests — 3 files, 134 tests passed
- `pnpm --filter @happyvertical/smrt-web test` — 14 files, 215 tests passed
- core and smrt-web typechecks and builds
- `pnpm --filter @happyvertical/smrt-web verify:pack`
- Biome on all nine changed source/test/docs files; `git diff --check`
- strict knowledge freshness and repository pre-push checks
- exact-head HIGH-RISK review at `d5ccde441`: Codex Sol CLEAN; Claude Fable CLEAN
- rebase proof: all six commits are patch-identical to the previously reviewed stack and the pre/post-rebase final trees are identical

<!-- hv-agent-run:v1 -->
```json
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "codex-webmcp-2519-20260826",
  "issue": 2519,
  "policy_revision": "1.0.0",
  "status": "complete",
  "validation": [
    "focused core tests: 134 passed",
    "pnpm --filter @happyvertical/smrt-web test: 215 passed",
    "core and smrt-web typecheck/build",
    "pnpm --filter @happyvertical/smrt-web verify:pack",
    "Biome, diff, knowledge, and pre-push checks",
    "review-cycle exact head: sol-clean,fable-clean"
  ]
}
```
