### PR TITLE
feat(svelte): expose mounted UI through WebMCP

### DIFF
--- a/packages/smrt-svelte/AGENTS.md
+++ b/packages/smrt-svelte/AGENTS.md
@@ -16,6 +16,7 @@ subpath you are editing. This file keeps what holds in every module.
 | `src/components/settings/` (`./settings`) | `SettingsCatalog`, `paginateSettingsCatalog`, and the summary-vs-detail scalability contract | [agents/settings.md](agents/settings.md) |
 | `src/components/workspace/` (`./workspace` + `./web`) | the AdminShell family and its principles, the legacy ToolsDock surface, the `./web` activity-feed and `updateAvailable` adapters, and server-side dock gates | [agents/workspace.md](agents/workspace.md) |
 | `src/web/remote-query.svelte.ts` | Svelte 5 binding for query-shaped remote pages: rows, page, totals, loading/refreshing/stale/error, retry, last-updated, and query-scoped live subscriptions (#2445) | — |
+| `src/web/webmcp-ui.ts` | Fixed, low-cardinality WebMCP adapter over the Provider's mounted form-control and data-surface registries (#2521) | — |
 
 ## The UI split — primitive-adoption contract (#1589)
 
@@ -63,6 +64,15 @@ Wraps app in `+layout.svelte`. Provides auth state, permissions, WebSocket, and 
   {@render children()}
 </Provider>
 ```
+
+With `webmcp` enabled, Provider also owns shared control/data-surface registries
+and registers six fixed `smrt_ui_*` tools. Descendant rich Forms use the shared
+control registry unless their explicit `interactionRegistry` prop overrides it.
+Supply `webmcp.ui.dataSurfaceRegistry` when mounted surface components already
+share an application registry. The adapter resolves registry state at execution
+time, never reads the DOM, never accepts agent confirmation, and removes the
+entire tool set with one abort signal. A document may have only one active
+adapter for a prefix; configure distinct prefixes for intentional coexistence.
 
 ## Hooks
 

--- a/packages/smrt-svelte/README.md
+++ b/packages/smrt-svelte/README.md
@@ -92,6 +92,44 @@ hydrating its whole collection. It exposes `rows`, `page`, `total`,
 </Provider>
 ```
 
+### Mounted UI through WebMCP
+
+`<Provider webmcp>` registers six fixed `smrt_ui_*` tools for the mounted UI:
+list, inspect, and execute for form controls and data surfaces. The tool set does
+not change as components mount and unmount; each call reads the current
+transport-neutral registries instead of inspecting or simulating the DOM.
+
+Forms automatically join the Provider's control registry. An explicit Form
+`interactionRegistry` still takes precedence. Pass the same data-surface
+registry used by `DataTable` or `CollectionToolbar` when those mounted surfaces
+should be discoverable:
+
+```svelte
+<script lang="ts">
+  import { createDataSurfaceRegistry } from '@happyvertical/smrt-ui/data';
+  import { Provider } from '@happyvertical/smrt-svelte';
+
+  const surfaces = createDataSurfaceRegistry();
+</script>
+
+<Provider webmcp={{ ui: { dataSurfaceRegistry: surfaces } }}>
+  <!-- pass {surfaces} to mounted data-surface components -->
+  {@render children()}
+</Provider>
+```
+
+The default prefix is `smrt_ui_`. Configure `ui.prefix` when multiple Providers
+must coexist in one document; the same prefix cannot be registered twice.
+`ui: false` disables only the fixed UI adapter while leaving generated model
+tools enabled.
+
+Form commands always run with `source: 'agent'`. WebMCP input cannot assert
+confirmation: staging is allowed by the registry policy, while apply, clear,
+and undo require a separate human-confirmed path. Secret control values and
+hidden data-surface columns are not serialized. Read responses are marked as
+untrusted content. Bespoke `useWebMcpTool` and `<Form webmcp>` tools retain their
+existing lifecycle and submit behavior.
+
 ### Form Components
 
 ```svelte

--- a/packages/smrt-svelte/README.md
+++ b/packages/smrt-svelte/README.md
@@ -121,7 +121,9 @@ should be discoverable:
 The default prefix is `smrt_ui_`. Configure `ui.prefix` when multiple Providers
 must coexist in one document; the same prefix cannot be registered twice.
 `ui: false` disables only the fixed UI adapter while leaving generated model
-tools enabled.
+tools enabled. For compatibility, an object config that omits `ui` continues to
+enable only generated model tools; use `webmcp={true}` or provide `ui: {}` to
+enable the mounted-UI adapter.
 
 Form commands always run with `source: 'agent'`. WebMCP input cannot assert
 confirmation: staging is allowed by the registry policy, while apply, clear,

--- a/packages/smrt-svelte/src/Provider.svelte
+++ b/packages/smrt-svelte/src/Provider.svelte
@@ -1,14 +1,11 @@
 <script lang="ts">
+import { createDataSurfaceRegistry } from '@happyvertical/smrt-ui/data';
+import { createControlInteractionRegistry } from '@happyvertical/smrt-ui/forms';
 import {
   createI18nContext,
   type I18nSnapshot,
   setI18nContext,
 } from '@happyvertical/smrt-ui/i18n';
-import {
-  type RegisterWebMcpToolsOptions,
-  type SmrtWebClient,
-  type SmrtWebCollectionDefinition,
-} from '@happyvertical/smrt-web';
 import type { Snippet } from 'svelte';
 import { onDestroy, untrack } from 'svelte';
 import { logger } from './internal/logger.js';
@@ -21,6 +18,9 @@ import type {
 } from './state/app-state.js';
 import { createAppState } from './state/app-state.svelte.js';
 import { setAppStateContext } from './state/context.js';
+import type { WebMcpProviderConfig } from './web/webmcp-provider.js';
+import { registerWebMcpUiTools } from './web/webmcp-ui.js';
+import { setWebMcpUiContext } from './web/webmcp-ui-context.js';
 
 interface Props {
   /**
@@ -84,24 +84,15 @@ interface Props {
    */
   i18n?: I18nSnapshot;
   /**
-   * Opt in to the generated collection tools for this browser surface.
-   * WebMCP is feature-detected by smrt-web, so this is safe during SSR and on
-   * browsers that do not expose `document.modelContext`.
+   * Opt in to generated data tools and the fixed mounted-UI tool adapter for
+   * this browser surface. WebMCP is feature-detected, so this is safe during
+   * SSR and on browsers that do not expose `document.modelContext`.
    */
   webmcp?: boolean | WebMcpProviderConfig;
   /**
    * Children to render
    */
   children: Snippet;
-}
-
-export interface WebMcpProviderConfig {
-  definitions?: SmrtWebCollectionDefinition[];
-  client?: SmrtWebClient;
-  basePath?: string;
-  fetchFn?: typeof fetch;
-  scope?: string;
-  filter?: RegisterWebMcpToolsOptions['filter'];
 }
 
 const {
@@ -135,6 +126,32 @@ const appState = createAppState({
   },
 });
 
+const localControlRegistry = createControlInteractionRegistry();
+const localDataSurfaceRegistry = createDataSurfaceRegistry();
+const webMcpConfig = $derived(typeof webmcp === 'object' ? webmcp : undefined);
+const webMcpUiConfig = $derived(
+  webMcpConfig?.ui === false
+    ? undefined
+    : typeof webMcpConfig?.ui === 'object'
+      ? webMcpConfig.ui
+      : {},
+);
+const resolvedControlRegistry = $derived(
+  webMcpUiConfig?.controlRegistry ?? localControlRegistry,
+);
+const resolvedDataSurfaceRegistry = $derived(
+  webMcpUiConfig?.dataSurfaceRegistry ?? localDataSurfaceRegistry,
+);
+
+setWebMcpUiContext({
+  get controlRegistry() {
+    return resolvedControlRegistry;
+  },
+  get dataSurfaceRegistry() {
+    return resolvedDataSurfaceRegistry;
+  },
+});
+
 $effect(() => {
   const currentPreferences = untrack(() => appState.state.session.preferences);
   if (currentPreferences.autoEnableSmrt === autoEnableSmrt) {
@@ -146,6 +163,17 @@ $effect(() => {
       ...currentPreferences,
       autoEnableSmrt,
     },
+  });
+});
+
+// Register one fixed UI tool set. Mounted components change registry contents,
+// not the document-level WebMCP tool set.
+$effect(() => {
+  if (typeof window === 'undefined' || !webmcp || !webMcpUiConfig) return;
+  return registerWebMcpUiTools({
+    controlRegistry: resolvedControlRegistry,
+    dataSurfaceRegistry: resolvedDataSurfaceRegistry,
+    ...(webMcpUiConfig.prefix ? { prefix: webMcpUiConfig.prefix } : {}),
   });
 });
 

--- a/packages/smrt-svelte/src/Provider.svelte
+++ b/packages/smrt-svelte/src/Provider.svelte
@@ -144,6 +144,9 @@ const resolvedDataSurfaceRegistry = $derived(
 );
 
 setWebMcpUiContext({
+  get enabled() {
+    return webMcpUiConfig !== undefined;
+  },
   get controlRegistry() {
     return resolvedControlRegistry;
   },

--- a/packages/smrt-svelte/src/Provider.svelte
+++ b/packages/smrt-svelte/src/Provider.svelte
@@ -130,11 +130,11 @@ const localControlRegistry = createControlInteractionRegistry();
 const localDataSurfaceRegistry = createDataSurfaceRegistry();
 const webMcpConfig = $derived(typeof webmcp === 'object' ? webmcp : undefined);
 const webMcpUiConfig = $derived(
-  webMcpConfig?.ui === false
-    ? undefined
+  webmcp === true
+    ? {}
     : typeof webMcpConfig?.ui === 'object'
       ? webMcpConfig.ui
-      : {},
+      : undefined,
 );
 const resolvedControlRegistry = $derived(
   webMcpUiConfig?.controlRegistry ?? localControlRegistry,

--- a/packages/smrt-svelte/src/Provider.svelte
+++ b/packages/smrt-svelte/src/Provider.svelte
@@ -173,11 +173,15 @@ $effect(() => {
 // not the document-level WebMCP tool set.
 $effect(() => {
   if (typeof window === 'undefined' || !webmcp || !webMcpUiConfig) return;
-  return registerWebMcpUiTools({
-    controlRegistry: resolvedControlRegistry,
-    dataSurfaceRegistry: resolvedDataSurfaceRegistry,
-    ...(webMcpUiConfig.prefix ? { prefix: webMcpUiConfig.prefix } : {}),
-  });
+  try {
+    return registerWebMcpUiTools({
+      controlRegistry: resolvedControlRegistry,
+      dataSurfaceRegistry: resolvedDataSurfaceRegistry,
+      ...(webMcpUiConfig.prefix ? { prefix: webMcpUiConfig.prefix } : {}),
+    });
+  } catch (error) {
+    logger.warn('Provider: WebMCP UI tool registration rejected', { error });
+  }
 });
 
 // Keep generated data-plane tools scoped to this Provider. The registrar

--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -145,47 +145,66 @@ function interactionKind(field: FieldDefinition): ControlKind {
   }
 }
 
+function registerInteraction(
+  registry: ControlInteractionRegistry,
+  currentFormId: string,
+  field: FieldDefinition,
+): () => void {
+  return registry.register({
+    identity: {
+      formId: currentFormId,
+      controlId: field.controlId ?? field.name,
+    },
+    metadata: {
+      kind: interactionKind(field),
+      label: field.label,
+      description: field.description,
+      sensitivity: field.sensitivity ?? 'public',
+      readable: field.readable,
+      writable: field.writable,
+      constraints: field.constraints,
+      options: field.options,
+      unit: field.unit,
+    },
+    getValue: field.getValue,
+    setValue: field.setValue,
+    clear: field.clear ?? (() => field.setValue('')),
+    focus: field.focus,
+    reveal: field.reveal,
+    highlight: field.highlight,
+    validate: field.validate,
+    getState: field.getState,
+  });
+}
+
+$effect(() => {
+  const registry = resolvedInteractionRegistry;
+  const currentFormId = resolvedFormId;
+  const currentFields = Array.from(fields.values());
+  for (const dispose of interactionDisposers.values()) dispose();
+  interactionDisposers.clear();
+  for (const field of currentFields) {
+    interactionDisposers.set(
+      field.name,
+      registerInteraction(registry, currentFormId, field),
+    );
+  }
+  return () => {
+    for (const dispose of interactionDisposers.values()) dispose();
+    interactionDisposers.clear();
+  };
+});
+
 // Create form context
 const formContext: SMRTFormContext = {
   get mode() {
     return app.state.mode === 'smrt' ? 'smrt' : 'default';
   },
   registerField(field: FieldDefinition) {
-    interactionDisposers.get(field.name)?.();
     fields.set(field.name, field);
     fields = new Map(fields); // Trigger reactivity
-    interactionDisposers.set(
-      field.name,
-      resolvedInteractionRegistry.register({
-        identity: {
-          formId: resolvedFormId,
-          controlId: field.controlId ?? field.name,
-        },
-        metadata: {
-          kind: interactionKind(field),
-          label: field.label,
-          description: field.description,
-          sensitivity: field.sensitivity ?? 'public',
-          readable: field.readable,
-          writable: field.writable,
-          constraints: field.constraints,
-          options: field.options,
-          unit: field.unit,
-        },
-        getValue: field.getValue,
-        setValue: field.setValue,
-        clear: field.clear ?? (() => field.setValue('')),
-        focus: field.focus,
-        reveal: field.reveal,
-        highlight: field.highlight,
-        validate: field.validate,
-        getState: field.getState,
-      }),
-    );
   },
   unregisterField(name: string) {
-    interactionDisposers.get(name)?.();
-    interactionDisposers.delete(name);
     fields.delete(name);
     fields = new Map(fields);
   },

--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -19,6 +19,7 @@ import {
   setFormContext,
 } from '../../state/form-context.js';
 import { useWebMcpTool } from '../../web/webmcp.svelte.js';
+import { tryGetWebMcpUiContext } from '../../web/webmcp-ui-context.js';
 import type { LLMModelId, STTAdapterType } from './types.js';
 
 const { t } = useI18n();
@@ -80,9 +81,12 @@ const stt = useSTT();
 const instanceId = $props.id();
 const generatedFormId = `smrt-form-${instanceId}`;
 const localInteractionRegistry = createControlInteractionRegistry();
+const providerWebMcpUi = tryGetWebMcpUiContext();
 const resolvedFormId = $derived(formId ?? id ?? name ?? generatedFormId);
 const resolvedInteractionRegistry = $derived(
-  interactionRegistry ?? localInteractionRegistry,
+  interactionRegistry ??
+    providerWebMcpUi?.controlRegistry ??
+    localInteractionRegistry,
 );
 const interactionDisposers = new Map<string, () => void>();
 

--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -101,7 +101,9 @@ setControlInteractionContext({
 
 $effect(() => {
   if (!oninteraction) return;
-  return resolvedInteractionRegistry.subscribe(oninteraction);
+  return resolvedInteractionRegistry.subscribe((event) => {
+    if (event.identity.formId === resolvedFormId) oninteraction(event);
+  });
 });
 
 // Internal state

--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -154,14 +154,14 @@ function registerInteraction(
   registry: ControlInteractionRegistry,
   currentFormId: string,
   field: FieldDefinition,
-): () => void {
+): (() => void) | undefined {
   const identity = {
     formId: currentFormId,
     controlId: field.controlId ?? field.name,
   };
   if (registry.get(identity)) {
     logger.warn('Form: duplicate interaction identity rejected', { identity });
-    return () => {};
+    return undefined;
   }
   return registry.register({
     identity,
@@ -187,10 +187,22 @@ function registerInteraction(
   });
 }
 
+let interactionRegistryRevision = $state(0);
+
+$effect(() => {
+  const registry = resolvedInteractionRegistry;
+  return registry.subscribe((event) => {
+    if (event.type === 'registered' || event.type === 'unregistered') {
+      interactionRegistryRevision += 1;
+    }
+  });
+});
+
 $effect(() => {
   const registry = resolvedInteractionRegistry;
   const currentFormId = resolvedFormId;
   const currentFields = new Map(fields);
+  void interactionRegistryRevision;
   if (
     activeInteractionRegistry !== registry ||
     activeInteractionFormId !== currentFormId
@@ -203,16 +215,25 @@ $effect(() => {
     activeInteractionFormId = currentFormId;
   }
   for (const [name, registration] of interactionDisposers) {
-    if (currentFields.get(name) !== registration.field) {
+    const identity = {
+      formId: currentFormId,
+      controlId: registration.field.controlId ?? registration.field.name,
+    };
+    if (
+      currentFields.get(name) !== registration.field ||
+      !registry.get(identity)
+    ) {
       registration.dispose();
       interactionDisposers.delete(name);
     }
   }
   for (const [name, field] of currentFields) {
     if (interactionDisposers.has(name)) continue;
+    const dispose = registerInteraction(registry, currentFormId, field);
+    if (!dispose) continue;
     interactionDisposers.set(name, {
       field,
-      dispose: registerInteraction(registry, currentFormId, field),
+      dispose,
     });
   }
 });

--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -104,7 +104,12 @@ setControlInteractionContext({
 $effect(() => {
   if (!oninteraction) return;
   return resolvedInteractionRegistry.subscribe((event) => {
-    if (event.identity.formId === resolvedFormId) oninteraction(event);
+    if (event.identity.formId !== resolvedFormId) return;
+    try {
+      oninteraction(event);
+    } catch (error) {
+      logger.warn('Form: interaction observer failed', { error });
+    }
   });
 });
 

--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -90,7 +90,12 @@ const resolvedInteractionRegistry = $derived(
       : undefined) ??
     localInteractionRegistry,
 );
-const interactionDisposers = new Map<string, () => void>();
+const interactionDisposers = new Map<
+  string,
+  { field: FieldDefinition; dispose: () => void }
+>();
+let activeInteractionRegistry: ControlInteractionRegistry | undefined;
+let activeInteractionFormId: string | undefined;
 
 setControlInteractionContext({
   get formId() {
@@ -150,11 +155,16 @@ function registerInteraction(
   currentFormId: string,
   field: FieldDefinition,
 ): () => void {
+  const identity = {
+    formId: currentFormId,
+    controlId: field.controlId ?? field.name,
+  };
+  if (registry.get(identity)) {
+    logger.warn('Form: duplicate interaction identity rejected', { identity });
+    return () => {};
+  }
   return registry.register({
-    identity: {
-      formId: currentFormId,
-      controlId: field.controlId ?? field.name,
-    },
+    identity,
     metadata: {
       kind: interactionKind(field),
       label: field.label,
@@ -180,19 +190,31 @@ function registerInteraction(
 $effect(() => {
   const registry = resolvedInteractionRegistry;
   const currentFormId = resolvedFormId;
-  const currentFields = Array.from(fields.values());
-  for (const dispose of interactionDisposers.values()) dispose();
-  interactionDisposers.clear();
-  for (const field of currentFields) {
-    interactionDisposers.set(
-      field.name,
-      registerInteraction(registry, currentFormId, field),
-    );
-  }
-  return () => {
-    for (const dispose of interactionDisposers.values()) dispose();
+  const currentFields = new Map(fields);
+  if (
+    activeInteractionRegistry !== registry ||
+    activeInteractionFormId !== currentFormId
+  ) {
+    for (const registration of interactionDisposers.values()) {
+      registration.dispose();
+    }
     interactionDisposers.clear();
-  };
+    activeInteractionRegistry = registry;
+    activeInteractionFormId = currentFormId;
+  }
+  for (const [name, registration] of interactionDisposers) {
+    if (currentFields.get(name) !== registration.field) {
+      registration.dispose();
+      interactionDisposers.delete(name);
+    }
+  }
+  for (const [name, field] of currentFields) {
+    if (interactionDisposers.has(name)) continue;
+    interactionDisposers.set(name, {
+      field,
+      dispose: registerInteraction(registry, currentFormId, field),
+    });
+  }
 });
 
 // Create form context
@@ -794,7 +816,9 @@ onDestroy(() => {
     clearTimeout(silenceTimer);
   }
   stopAudioLevelMonitoring();
-  for (const dispose of interactionDisposers.values()) dispose();
+  for (const registration of interactionDisposers.values()) {
+    registration.dispose();
+  }
   interactionDisposers.clear();
 });
 

--- a/packages/smrt-svelte/src/components/forms/Form.svelte
+++ b/packages/smrt-svelte/src/components/forms/Form.svelte
@@ -85,7 +85,9 @@ const providerWebMcpUi = tryGetWebMcpUiContext();
 const resolvedFormId = $derived(formId ?? id ?? name ?? generatedFormId);
 const resolvedInteractionRegistry = $derived(
   interactionRegistry ??
-    providerWebMcpUi?.controlRegistry ??
+    (providerWebMcpUi?.enabled
+      ? providerWebMcpUi.controlRegistry
+      : undefined) ??
     localInteractionRegistry,
 );
 const interactionDisposers = new Map<string, () => void>();

--- a/packages/smrt-svelte/src/index.ts
+++ b/packages/smrt-svelte/src/index.ts
@@ -28,3 +28,15 @@ export { default as Provider } from './Provider.svelte';
 export * from './state/index.js';
 // Opt-in browser WebMCP lifecycle primitive.
 export { useWebMcpTool, type WebMcpToolSpec } from './web/webmcp.svelte.js';
+export type {
+  WebMcpProviderConfig,
+  WebMcpUiProviderConfig,
+} from './web/webmcp-provider.js';
+export {
+  type RegisterWebMcpUiToolsOptions,
+  registerWebMcpUiTools,
+} from './web/webmcp-ui.js';
+export {
+  useWebMcpUi,
+  type WebMcpUiContext,
+} from './web/webmcp-ui-context.js';

--- a/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.fixture.svelte
+++ b/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.fixture.svelte
@@ -13,12 +13,14 @@ let {
   enableUi = true,
   onSharedInteraction,
   onSiblingInteraction,
+  showSibling = true,
 }: {
   providerRegistry: ControlInteractionRegistry;
   explicitRegistry: ControlInteractionRegistry;
   enableUi?: boolean;
   onSharedInteraction?: (event: ControlInteractionEvent) => void;
   onSiblingInteraction?: (event: ControlInteractionEvent) => void;
+  showSibling?: boolean;
 } = $props();
 </script>
 
@@ -30,9 +32,11 @@ let {
   <Form formId="shared-form" oninteraction={onSharedInteraction}>
     <TextInput name="shared-name" label="Shared name" />
   </Form>
-  <Form formId="sibling-form" oninteraction={onSiblingInteraction}>
-    <TextInput name="sibling-name" label="Sibling name" />
-  </Form>
+  {#if showSibling}
+    <Form formId="sibling-form" oninteraction={onSiblingInteraction}>
+      <TextInput name="sibling-name" label="Sibling name" />
+    </Form>
+  {/if}
   <Form formId="explicit-form" interactionRegistry={explicitRegistry}>
     <TextInput name="explicit-name" label="Explicit name" />
   </Form>

--- a/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.fixture.svelte
+++ b/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.fixture.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+import type { ControlInteractionRegistry } from '@happyvertical/smrt-ui/forms';
+import Form from '../../components/forms/Form.svelte';
+import TextInput from '../../components/forms/TextInput.svelte';
+import Provider from '../../Provider.svelte';
+
+let {
+  providerRegistry,
+  explicitRegistry,
+}: {
+  providerRegistry: ControlInteractionRegistry;
+  explicitRegistry: ControlInteractionRegistry;
+} = $props();
+</script>
+
+<Provider webmcp={{ ui: { controlRegistry: providerRegistry } }}>
+  <Form formId="shared-form">
+    <TextInput name="shared-name" label="Shared name" />
+  </Form>
+  <Form formId="explicit-form" interactionRegistry={explicitRegistry}>
+    <TextInput name="explicit-name" label="Explicit name" />
+  </Form>
+</Provider>

--- a/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.fixture.svelte
+++ b/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.fixture.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-import type { ControlInteractionRegistry } from '@happyvertical/smrt-ui/forms';
+import type {
+  ControlInteractionEvent,
+  ControlInteractionRegistry,
+} from '@happyvertical/smrt-ui/forms';
 import Form from '../../components/forms/Form.svelte';
 import TextInput from '../../components/forms/TextInput.svelte';
 import Provider from '../../Provider.svelte';
@@ -8,10 +11,14 @@ let {
   providerRegistry,
   explicitRegistry,
   enableUi = true,
+  onSharedInteraction,
+  onSiblingInteraction,
 }: {
   providerRegistry: ControlInteractionRegistry;
   explicitRegistry: ControlInteractionRegistry;
   enableUi?: boolean;
+  onSharedInteraction?: (event: ControlInteractionEvent) => void;
+  onSiblingInteraction?: (event: ControlInteractionEvent) => void;
 } = $props();
 </script>
 
@@ -20,8 +27,11 @@ let {
     ? { ui: { controlRegistry: providerRegistry } }
     : { definitions: [] }}
 >
-  <Form formId="shared-form">
+  <Form formId="shared-form" oninteraction={onSharedInteraction}>
     <TextInput name="shared-name" label="Shared name" />
+  </Form>
+  <Form formId="sibling-form" oninteraction={onSiblingInteraction}>
+    <TextInput name="sibling-name" label="Sibling name" />
   </Form>
   <Form formId="explicit-form" interactionRegistry={explicitRegistry}>
     <TextInput name="explicit-name" label="Explicit name" />

--- a/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.fixture.svelte
+++ b/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.fixture.svelte
@@ -7,13 +7,19 @@ import Provider from '../../Provider.svelte';
 let {
   providerRegistry,
   explicitRegistry,
+  enableUi = true,
 }: {
   providerRegistry: ControlInteractionRegistry;
   explicitRegistry: ControlInteractionRegistry;
+  enableUi?: boolean;
 } = $props();
 </script>
 
-<Provider webmcp={{ ui: { controlRegistry: providerRegistry } }}>
+<Provider
+  webmcp={enableUi
+    ? { ui: { controlRegistry: providerRegistry } }
+    : { definitions: [] }}
+>
   <Form formId="shared-form">
     <TextInput name="shared-name" label="Shared name" />
   </Form>

--- a/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.test.ts
@@ -81,6 +81,29 @@ describe('Provider WebMCP UI registry context', () => {
     view.unmount();
   });
 
+  it('isolates throwing interaction observers from registry command outcomes', async () => {
+    const providerRegistry = createControlInteractionRegistry();
+    const view = render(Fixture, {
+      props: {
+        providerRegistry,
+        explicitRegistry: createControlInteractionRegistry(),
+        onSiblingInteraction: () => {
+          throw new Error('observer failed');
+        },
+      },
+    });
+    await tick();
+
+    await expect(
+      providerRegistry.execute({
+        action: 'stage',
+        identity: { formId: 'sibling-form', controlId: 'sibling-name' },
+        value: 'still staged',
+      }),
+    ).resolves.toMatchObject({ ok: true, action: 'stage' });
+    view.unmount();
+  });
+
   it('preserves legacy object configs that did not opt into UI tools', async () => {
     const names: string[] = [];
     const providerRegistry = createControlInteractionRegistry();

--- a/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.test.ts
@@ -83,6 +83,7 @@ describe('Provider WebMCP UI registry context', () => {
 
   it('preserves legacy object configs that did not opt into UI tools', async () => {
     const names: string[] = [];
+    const providerRegistry = createControlInteractionRegistry();
     document.modelContext = {
       registerTool(tool) {
         names.push(tool.name);
@@ -90,7 +91,7 @@ describe('Provider WebMCP UI registry context', () => {
     };
     const view = render(Fixture, {
       props: {
-        providerRegistry: createControlInteractionRegistry(),
+        providerRegistry,
         explicitRegistry: createControlInteractionRegistry(),
         enableUi: false,
       },
@@ -98,6 +99,7 @@ describe('Provider WebMCP UI registry context', () => {
     await tick();
 
     expect(names).toEqual([]);
+    expect(providerRegistry.list()).toEqual([]);
     view.unmount();
   });
 });

--- a/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.test.ts
@@ -81,6 +81,27 @@ describe('Provider WebMCP UI registry context', () => {
     view.unmount();
   });
 
+  it('moves mounted controls when the Provider registry changes', async () => {
+    const firstRegistry = createControlInteractionRegistry();
+    const secondRegistry = createControlInteractionRegistry();
+    const explicitRegistry = createControlInteractionRegistry();
+    const view = render(Fixture, {
+      props: { providerRegistry: firstRegistry, explicitRegistry },
+    });
+    await tick();
+    expect(firstRegistry.list()).toHaveLength(2);
+
+    await view.rerender({
+      providerRegistry: secondRegistry,
+      explicitRegistry,
+    });
+    await tick();
+
+    expect(firstRegistry.list()).toEqual([]);
+    expect(secondRegistry.list()).toHaveLength(2);
+    view.unmount();
+  });
+
   it('isolates throwing interaction observers from registry command outcomes', async () => {
     const providerRegistry = createControlInteractionRegistry();
     const view = render(Fixture, {

--- a/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.test.ts
@@ -131,7 +131,7 @@ describe('Provider WebMCP UI registry context', () => {
     view.unmount();
   });
 
-  it('does not clobber an existing shared interaction identity', async () => {
+  it('retries a shared identity after the existing registration unmounts', async () => {
     const providerRegistry = createControlInteractionRegistry();
     const unregisterExisting = providerRegistry.register({
       identity: { formId: 'shared-form', controlId: 'shared-name' },
@@ -152,14 +152,55 @@ describe('Provider WebMCP UI registry context', () => {
         controlId: 'shared-name',
       })?.state.value,
     ).toBe('existing value');
+    unregisterExisting();
+    await tick();
+    expect(
+      providerRegistry.get({
+        formId: 'shared-form',
+        controlId: 'shared-name',
+      })?.metadata.label,
+    ).toBe('Shared name');
     view.unmount();
     expect(
       providerRegistry.get({
         formId: 'shared-form',
         controlId: 'shared-name',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('recovers after its shared identity is displaced and removed', async () => {
+    const providerRegistry = createControlInteractionRegistry();
+    const view = render(Fixture, {
+      props: {
+        providerRegistry,
+        explicitRegistry: createControlInteractionRegistry(),
+      },
+    });
+    await tick();
+
+    const unregisterReplacement = providerRegistry.register({
+      identity: { formId: 'shared-form', controlId: 'shared-name' },
+      metadata: { kind: 'text', label: 'Replacement' },
+      getValue: () => 'replacement value',
+    });
+    await tick();
+    expect(
+      providerRegistry.get({
+        formId: 'shared-form',
+        controlId: 'shared-name',
       })?.state.value,
-    ).toBe('existing value');
-    unregisterExisting();
+    ).toBe('replacement value');
+
+    unregisterReplacement();
+    await tick();
+    expect(
+      providerRegistry.get({
+        formId: 'shared-form',
+        controlId: 'shared-name',
+      })?.metadata.label,
+    ).toBe('Shared name');
+    view.unmount();
   });
 
   it('contains duplicate Provider prefixes without crashing the app', async () => {

--- a/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.test.ts
@@ -47,4 +47,24 @@ describe('Provider WebMCP UI registry context', () => {
     expect(signals).toHaveLength(6);
     expect(signals.every((signal) => signal.aborted)).toBe(true);
   });
+
+  it('preserves legacy object configs that did not opt into UI tools', async () => {
+    const names: string[] = [];
+    document.modelContext = {
+      registerTool(tool) {
+        names.push(tool.name);
+      },
+    };
+    const view = render(Fixture, {
+      props: {
+        providerRegistry: createControlInteractionRegistry(),
+        explicitRegistry: createControlInteractionRegistry(),
+        enableUi: false,
+      },
+    });
+    await tick();
+
+    expect(names).toEqual([]);
+    view.unmount();
+  });
 });

--- a/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.test.ts
@@ -102,6 +102,93 @@ describe('Provider WebMCP UI registry context', () => {
     view.unmount();
   });
 
+  it('preserves staged sibling state when another field unmounts', async () => {
+    const providerRegistry = createControlInteractionRegistry();
+    const explicitRegistry = createControlInteractionRegistry();
+    const view = render(Fixture, {
+      props: { providerRegistry, explicitRegistry },
+    });
+    await tick();
+    await providerRegistry.execute({
+      action: 'stage',
+      identity: { formId: 'shared-form', controlId: 'shared-name' },
+      value: 'keep staged',
+    });
+
+    await view.rerender({
+      providerRegistry,
+      explicitRegistry,
+      showSibling: false,
+    });
+    await tick();
+
+    expect(
+      providerRegistry.get({
+        formId: 'shared-form',
+        controlId: 'shared-name',
+      })?.state.stagedValue,
+    ).toBe('keep staged');
+    view.unmount();
+  });
+
+  it('does not clobber an existing shared interaction identity', async () => {
+    const providerRegistry = createControlInteractionRegistry();
+    const unregisterExisting = providerRegistry.register({
+      identity: { formId: 'shared-form', controlId: 'shared-name' },
+      metadata: { kind: 'text', label: 'Existing' },
+      getValue: () => 'existing value',
+    });
+    const view = render(Fixture, {
+      props: {
+        providerRegistry,
+        explicitRegistry: createControlInteractionRegistry(),
+      },
+    });
+    await tick();
+
+    expect(
+      providerRegistry.get({
+        formId: 'shared-form',
+        controlId: 'shared-name',
+      })?.state.value,
+    ).toBe('existing value');
+    view.unmount();
+    expect(
+      providerRegistry.get({
+        formId: 'shared-form',
+        controlId: 'shared-name',
+      })?.state.value,
+    ).toBe('existing value');
+    unregisterExisting();
+  });
+
+  it('contains duplicate Provider prefixes without crashing the app', async () => {
+    const names: string[] = [];
+    document.modelContext = {
+      registerTool(tool) {
+        names.push(tool.name);
+      },
+    };
+    const first = render(Fixture, {
+      props: {
+        providerRegistry: createControlInteractionRegistry(),
+        explicitRegistry: createControlInteractionRegistry(),
+      },
+    });
+    await tick();
+    const second = render(Fixture, {
+      props: {
+        providerRegistry: createControlInteractionRegistry(),
+        explicitRegistry: createControlInteractionRegistry(),
+      },
+    });
+    await tick();
+
+    expect(names).toHaveLength(6);
+    second.unmount();
+    first.unmount();
+  });
+
   it('isolates throwing interaction observers from registry command outcomes', async () => {
     const providerRegistry = createControlInteractionRegistry();
     const view = render(Fixture, {

--- a/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.test.ts
@@ -1,0 +1,50 @@
+import { createControlInteractionRegistry } from '@happyvertical/smrt-ui/forms';
+import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import Fixture from './provider-ui-registry.fixture.svelte';
+
+afterEach(() => {
+  delete document.modelContext;
+});
+
+describe('Provider WebMCP UI registry context', () => {
+  it('aggregates descendant forms while preserving explicit registry overrides', async () => {
+    const providerRegistry = createControlInteractionRegistry();
+    const explicitRegistry = createControlInteractionRegistry();
+    const signals: AbortSignal[] = [];
+    const names: string[] = [];
+    document.modelContext = {
+      registerTool(tool, options) {
+        names.push(tool.name);
+        if (options?.signal) signals.push(options.signal);
+      },
+    };
+    const view = render(Fixture, {
+      props: { providerRegistry, explicitRegistry },
+    });
+    await tick();
+
+    expect(names).toEqual([
+      'smrt_ui_list_form_controls',
+      'smrt_ui_inspect_form_control',
+      'smrt_ui_execute_form_control',
+      'smrt_ui_list_data_surfaces',
+      'smrt_ui_inspect_data_surface',
+      'smrt_ui_execute_data_surface_control',
+    ]);
+
+    expect(providerRegistry.list().map((entry) => entry.identity)).toEqual([
+      { formId: 'shared-form', controlId: 'shared-name' },
+    ]);
+    expect(explicitRegistry.list().map((entry) => entry.identity)).toEqual([
+      { formId: 'explicit-form', controlId: 'explicit-name' },
+    ]);
+
+    view.unmount();
+    expect(providerRegistry.list()).toEqual([]);
+    expect(explicitRegistry.list()).toEqual([]);
+    expect(signals).toHaveLength(6);
+    expect(signals.every((signal) => signal.aborted)).toBe(true);
+  });
+});

--- a/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/provider-ui-registry.test.ts
@@ -1,7 +1,7 @@
 import { createControlInteractionRegistry } from '@happyvertical/smrt-ui/forms';
 import { render } from '@testing-library/svelte';
 import { tick } from 'svelte';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import Fixture from './provider-ui-registry.fixture.svelte';
 
 afterEach(() => {
@@ -36,6 +36,7 @@ describe('Provider WebMCP UI registry context', () => {
 
     expect(providerRegistry.list().map((entry) => entry.identity)).toEqual([
       { formId: 'shared-form', controlId: 'shared-name' },
+      { formId: 'sibling-form', controlId: 'sibling-name' },
     ]);
     expect(explicitRegistry.list().map((entry) => entry.identity)).toEqual([
       { formId: 'explicit-form', controlId: 'explicit-name' },
@@ -46,6 +47,38 @@ describe('Provider WebMCP UI registry context', () => {
     expect(explicitRegistry.list()).toEqual([]);
     expect(signals).toHaveLength(6);
     expect(signals.every((signal) => signal.aborted)).toBe(true);
+  });
+
+  it('keeps form interaction callbacks scoped when forms share a Provider registry', async () => {
+    const providerRegistry = createControlInteractionRegistry();
+    const onSharedInteraction = vi.fn();
+    const onSiblingInteraction = vi.fn();
+    const view = render(Fixture, {
+      props: {
+        providerRegistry,
+        explicitRegistry: createControlInteractionRegistry(),
+        onSharedInteraction,
+        onSiblingInteraction,
+      },
+    });
+    await tick();
+    onSharedInteraction.mockClear();
+    onSiblingInteraction.mockClear();
+
+    await providerRegistry.execute({
+      action: 'stage',
+      identity: { formId: 'sibling-form', controlId: 'sibling-name' },
+      value: 'private sibling value',
+    });
+
+    expect(onSharedInteraction).not.toHaveBeenCalled();
+    expect(onSiblingInteraction).toHaveBeenCalled();
+    expect(
+      onSiblingInteraction.mock.calls.every(
+        ([event]) => event.identity.formId === 'sibling-form',
+      ),
+    ).toBe(true);
+    view.unmount();
   });
 
   it('preserves legacy object configs that did not opt into UI tools', async () => {

--- a/packages/smrt-svelte/src/web/__tests__/webmcp-ui.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/webmcp-ui.test.ts
@@ -299,6 +299,7 @@ describe('registerWebMcpUiTools', () => {
             state: {
               filters: [
                 { columnId: 'internal', value: 'nested-hidden-filter' },
+                { columnId: 'id', value: ['internal'] },
               ],
               sorting: [{ columnId: 'internal', direction: 'asc' }],
               columnOrder: ['id', 'internal'],
@@ -333,6 +334,9 @@ describe('registerWebMcpUiTools', () => {
     expect(snapshot.state).not.toHaveProperty('internal');
     expect(JSON.stringify(snapshot)).not.toContain('nested-hidden-filter');
     expect(snapshot.state.table.state.columnOrder).toEqual(['id']);
+    expect(snapshot.state.table.state.filters).toEqual([
+      { columnId: 'id', value: ['internal'] },
+    ]);
 
     const hiddenRowKeyDescriptor = descriptor();
     hiddenRowKeyDescriptor.rowKey = 'internal';

--- a/packages/smrt-svelte/src/web/__tests__/webmcp-ui.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/webmcp-ui.test.ts
@@ -230,10 +230,12 @@ describe('registerWebMcpUiTools', () => {
       expectedRevision: 2,
       controlId: 'next-page',
     };
-    expect((await parse(execute.execute(command))).result).toMatchObject({
+    const completed = (await parse(execute.execute(command))).result;
+    expect(completed).toMatchObject({
       ok: true,
       revision: 3,
     });
+    expect(completed.snapshot.descriptor.columns).toHaveLength(1);
     expect((await parse(execute.execute(command))).result).toMatchObject({
       ok: true,
       revision: 3,
@@ -245,10 +247,11 @@ describe('registerWebMcpUiTools', () => {
         )
       ).result,
     ).toMatchObject({ ok: false, reason: 'idempotency_conflict' });
-    expect(
-      (await parse(execute.execute({ ...command, commandId: 'page-2' })))
-        .result,
-    ).toMatchObject({ ok: false, reason: 'stale_revision' });
+    const stale = (
+      await parse(execute.execute({ ...command, commandId: 'page-2' }))
+    ).result;
+    expect(stale).toMatchObject({ ok: false, reason: 'stale_revision' });
+    expect(stale.snapshot.descriptor.columns).toHaveLength(1);
   });
 
   it('rejects invalid and oversized requests with distinct failures', async () => {

--- a/packages/smrt-svelte/src/web/__tests__/webmcp-ui.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/webmcp-ui.test.ts
@@ -243,7 +243,11 @@ describe('registerWebMcpUiTools', () => {
     const hiddenRowKeySurfaces = createDataSurfaceRegistry();
     hiddenRowKeySurfaces.register({
       descriptor: hiddenRowKeyDescriptor,
-      getSnapshot: () => ({ revision: 0, state: {} }),
+      getSnapshot: () => ({
+        revision: 0,
+        state: {},
+        selection: { scope: 'explicit-ids', rowIds: ['private-row-id'] },
+      }),
     });
     const hiddenRowKeyBrowser = modelContext();
     registerWebMcpUiTools({
@@ -258,6 +262,14 @@ describe('registerWebMcpUiTools', () => {
       ).execute({}),
     );
     expect(hiddenRowKeyList.result[0]).not.toHaveProperty('rowKey');
+    const hiddenRowKeyInspect = await parse(
+      findTool(
+        hiddenRowKeyBrowser.registered,
+        'smrt_ui_inspect_data_surface',
+      ).execute({ identity }),
+    );
+    expect(hiddenRowKeyInspect.result.selection).toBeNull();
+    expect(JSON.stringify(hiddenRowKeyInspect)).not.toContain('private-row-id');
 
     const command = {
       version: 1,

--- a/packages/smrt-svelte/src/web/__tests__/webmcp-ui.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/webmcp-ui.test.ts
@@ -166,6 +166,13 @@ describe('registerWebMcpUiTools', () => {
       },
       getValue: () => 'never-serialize-this',
       setValue: () => {},
+      getState: () => ({
+        valid: false,
+        validationMessage: 'never-serialize-this is invalid',
+      }),
+      focus: () => {
+        throw new Error('never-serialize-this cannot be focused');
+      },
     });
     registerWebMcpUiTools({
       controlRegistry: controls,
@@ -199,6 +206,39 @@ describe('registerWebMcpUiTools', () => {
     expect(listed.result[0].state.valueRedacted).toBe(true);
     expect(inspected.result.state.valueRedacted).toBe(true);
     expect(executed.result.snapshot.state.valueRedacted).toBe(true);
+    expect(executed.result.snapshot.state).not.toHaveProperty(
+      'validationMessage',
+    );
+    expect(executed.result.reason).toBe('execution_failed');
+  });
+
+  it('does not expose host error messages that mimic public failures', async () => {
+    const browser = modelContext();
+    const controls = createControlInteractionRegistry();
+    controls.register({
+      identity: { formId: 'profile', controlId: 'unstable' },
+      metadata: { kind: 'text', label: 'Unstable' },
+      getValue: () => {
+        throw new Error('not_found: private customer 4711');
+      },
+    });
+    registerWebMcpUiTools({
+      controlRegistry: controls,
+      dataSurfaceRegistry: createDataSurfaceRegistry(),
+      document: browser.document,
+    });
+    const inspect = findTool(
+      browser.registered,
+      'smrt_ui_inspect_form_control',
+    );
+
+    const result = await parse(
+      inspect.execute({
+        identity: { formId: 'profile', controlId: 'unstable' },
+      }),
+    );
+    expect(result).toEqual({ ok: false, reason: 'execution_failed' });
+    expect(JSON.stringify(result)).not.toContain('customer 4711');
   });
 
   it('filters hidden columns and preserves surface revision and replay failures', async () => {
@@ -210,7 +250,19 @@ describe('registerWebMcpUiTools', () => {
       descriptor: descriptor(),
       getSnapshot: () => ({
         revision,
-        state: { page, internal: 'never-serialize-this' },
+        state: {
+          page,
+          internal: 'never-serialize-this',
+          table: {
+            version: 3,
+            state: {
+              filters: [
+                { columnId: 'internal', value: 'nested-hidden-filter' },
+              ],
+              sorting: [{ columnId: 'internal', direction: 'asc' }],
+            },
+          },
+        },
       }),
       execute: (_command: DataSurfaceVisibleCommand) => {
         page += 1;
@@ -237,6 +289,7 @@ describe('registerWebMcpUiTools', () => {
     const snapshot = (await parse(inspect.execute({ identity }))).result;
     expect(snapshot.descriptor.query.projectableColumnIds).toEqual(['id']);
     expect(snapshot.state).not.toHaveProperty('internal');
+    expect(JSON.stringify(snapshot)).not.toContain('nested-hidden-filter');
 
     const hiddenRowKeyDescriptor = descriptor();
     hiddenRowKeyDescriptor.rowKey = 'internal';
@@ -245,7 +298,18 @@ describe('registerWebMcpUiTools', () => {
       descriptor: hiddenRowKeyDescriptor,
       getSnapshot: () => ({
         revision: 0,
-        state: {},
+        state: {
+          table: {
+            state: {
+              selection: {
+                scope: 'explicit',
+                rowIds: ['nested-private-row-id'],
+              },
+              selectedRowIds: ['nested-private-row-id'],
+              expandedRowIds: ['nested-private-row-id'],
+            },
+          },
+        },
         selection: { scope: 'explicit-ids', rowIds: ['private-row-id'] },
       }),
     });
@@ -270,6 +334,9 @@ describe('registerWebMcpUiTools', () => {
     );
     expect(hiddenRowKeyInspect.result.selection).toBeNull();
     expect(JSON.stringify(hiddenRowKeyInspect)).not.toContain('private-row-id');
+    expect(JSON.stringify(hiddenRowKeyInspect)).not.toContain(
+      'nested-private-row-id',
+    );
 
     const command = {
       version: 1,

--- a/packages/smrt-svelte/src/web/__tests__/webmcp-ui.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/webmcp-ui.test.ts
@@ -208,7 +208,10 @@ describe('registerWebMcpUiTools', () => {
     let page = 1;
     surfaces.register({
       descriptor: descriptor(),
-      getSnapshot: () => ({ revision, state: { page } }),
+      getSnapshot: () => ({
+        revision,
+        state: { page, internal: 'never-serialize-this' },
+      }),
       execute: (_command: DataSurfaceVisibleCommand) => {
         page += 1;
         revision += 1;
@@ -233,6 +236,7 @@ describe('registerWebMcpUiTools', () => {
     expect((await parse(list.execute({}))).result[0].columns).toHaveLength(1);
     const snapshot = (await parse(inspect.execute({ identity }))).result;
     expect(snapshot.descriptor.query.projectableColumnIds).toEqual(['id']);
+    expect(snapshot.state).not.toHaveProperty('internal');
 
     const hiddenRowKeyDescriptor = descriptor();
     hiddenRowKeyDescriptor.rowKey = 'internal';
@@ -268,6 +272,7 @@ describe('registerWebMcpUiTools', () => {
       revision: 3,
     });
     expect(completed.snapshot.descriptor.columns).toHaveLength(1);
+    expect(completed.snapshot.state).not.toHaveProperty('internal');
     expect((await parse(execute.execute(command))).result).toMatchObject({
       ok: true,
       revision: 3,

--- a/packages/smrt-svelte/src/web/__tests__/webmcp-ui.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/webmcp-ui.test.ts
@@ -1,0 +1,362 @@
+import {
+  createDataSurfaceRegistry,
+  type DataSurfaceDescriptor,
+  type DataSurfaceVisibleCommand,
+} from '@happyvertical/smrt-ui/data';
+import { createControlInteractionRegistry } from '@happyvertical/smrt-ui/forms';
+import { describe, expect, it, vi } from 'vitest';
+import type { WebMcpToolSpec } from '../webmcp.svelte.js';
+import { registerWebMcpUiTools } from '../webmcp-ui.js';
+
+function modelContext() {
+  const registered: WebMcpToolSpec[] = [];
+  const signals: AbortSignal[] = [];
+  const document = {
+    modelContext: {
+      registerTool(tool: WebMcpToolSpec, options?: { signal?: AbortSignal }) {
+        registered.push(tool);
+        if (options?.signal) signals.push(options.signal);
+      },
+    },
+  };
+  return { document, registered, signals };
+}
+
+function parse(value: string | Promise<string>) {
+  return Promise.resolve(value).then((result) => JSON.parse(result));
+}
+
+function findTool(tools: WebMcpToolSpec[], name: string): WebMcpToolSpec {
+  const tool = tools.find((candidate) => candidate.name === name);
+  if (!tool) throw new Error(`Missing tool: ${name}`);
+  return tool;
+}
+
+function descriptor(): DataSurfaceDescriptor {
+  return {
+    version: 1,
+    identity: { surfaceId: 'content', kind: 'table' },
+    schemaVersion: 1,
+    label: 'Content',
+    rowKey: 'id',
+    columns: [
+      {
+        id: 'id',
+        label: 'ID',
+        capabilities: ['read', 'project'],
+      },
+      {
+        id: 'internal',
+        label: 'Internal',
+        visibility: 'hidden',
+        capabilities: ['read', 'project'],
+      },
+    ],
+    query: {
+      modes: ['rows'],
+      projectableColumnIds: ['id', 'internal'],
+    },
+    controls: [{ id: 'next-page', label: 'Next page' }],
+    actions: [],
+    limits: { maxQueryRows: 50, maxQueryBytes: 10_000, maxSelectionSize: 10 },
+  };
+}
+
+describe('registerWebMcpUiTools', () => {
+  it('registers one fixed tool set and resolves mounted controls dynamically', async () => {
+    const browser = modelContext();
+    const controls = createControlInteractionRegistry();
+    const surfaces = createDataSurfaceRegistry();
+    const dispose = registerWebMcpUiTools({
+      controlRegistry: controls,
+      dataSurfaceRegistry: surfaces,
+      document: browser.document,
+    });
+
+    expect(browser.registered.map((tool) => tool.name)).toEqual([
+      'smrt_ui_list_form_controls',
+      'smrt_ui_inspect_form_control',
+      'smrt_ui_execute_form_control',
+      'smrt_ui_list_data_surfaces',
+      'smrt_ui_inspect_data_surface',
+      'smrt_ui_execute_data_surface_control',
+    ]);
+    expect(browser.registered).toHaveLength(6);
+
+    const list = findTool(browser.registered, 'smrt_ui_list_form_controls');
+    expect(await parse(list.execute({}))).toEqual({ ok: true, result: [] });
+
+    let value = 'Ada';
+    const unregister = controls.register({
+      identity: { formId: 'profile', controlId: 'name' },
+      metadata: { kind: 'text', label: 'Name' },
+      getValue: () => value,
+      setValue: (next) => {
+        value = String(next);
+      },
+      focus: vi.fn(),
+    });
+    expect((await parse(list.execute({}))).result).toHaveLength(1);
+    expect(browser.registered).toHaveLength(6);
+
+    unregister();
+    expect(await parse(list.execute({}))).toEqual({ ok: true, result: [] });
+    dispose();
+    expect(browser.signals).toHaveLength(6);
+    expect(browser.signals.every((signal) => signal.aborted)).toBe(true);
+  });
+
+  it('uses agent consent semantics and cannot be tricked into confirmation', async () => {
+    const browser = modelContext();
+    const controls = createControlInteractionRegistry();
+    let value = 'Ada';
+    controls.register({
+      identity: { formId: 'profile', controlId: 'name' },
+      metadata: { kind: 'text', label: 'Name' },
+      getValue: () => value,
+      setValue: (next) => {
+        value = String(next);
+      },
+    });
+    registerWebMcpUiTools({
+      controlRegistry: controls,
+      dataSurfaceRegistry: createDataSurfaceRegistry(),
+      document: browser.document,
+    });
+    const execute = findTool(
+      browser.registered,
+      'smrt_ui_execute_form_control',
+    );
+    const identity = { formId: 'profile', controlId: 'name' };
+
+    expect(
+      (
+        await parse(
+          execute.execute({ action: 'stage', identity, value: 'Grace' }),
+        )
+      ).result,
+    ).toMatchObject({ ok: true, action: 'stage' });
+    expect(value).toBe('Ada');
+    expect(
+      (await parse(execute.execute({ action: 'apply', identity }))).result,
+    ).toMatchObject({ ok: false, reason: 'consent_required' });
+    expect(value).toBe('Ada');
+
+    expect(
+      await parse(
+        execute.execute({
+          action: 'apply',
+          identity,
+          confirmed: true,
+        }),
+      ),
+    ).toEqual({ ok: false, reason: 'invalid_request', details: 'confirmed' });
+    expect(value).toBe('Ada');
+  });
+
+  it('keeps secret values redacted from list and inspect responses', async () => {
+    const browser = modelContext();
+    const controls = createControlInteractionRegistry();
+    controls.register({
+      identity: { formId: 'account', controlId: 'password' },
+      metadata: {
+        kind: 'password',
+        label: 'Password',
+        sensitivity: 'secret',
+      },
+      getValue: () => 'never-serialize-this',
+      setValue: () => {},
+    });
+    registerWebMcpUiTools({
+      controlRegistry: controls,
+      dataSurfaceRegistry: createDataSurfaceRegistry(),
+      document: browser.document,
+    });
+    const list = findTool(browser.registered, 'smrt_ui_list_form_controls');
+    const inspect = findTool(
+      browser.registered,
+      'smrt_ui_inspect_form_control',
+    );
+    const listed = await parse(list.execute({ formId: 'account' }));
+    const inspected = await parse(
+      inspect.execute({
+        identity: { formId: 'account', controlId: 'password' },
+      }),
+    );
+    expect(JSON.stringify([listed, inspected])).not.toContain(
+      'never-serialize-this',
+    );
+    expect(listed.result[0].state.valueRedacted).toBe(true);
+    expect(inspected.result.state.valueRedacted).toBe(true);
+  });
+
+  it('filters hidden columns and preserves surface revision and replay failures', async () => {
+    const browser = modelContext();
+    const surfaces = createDataSurfaceRegistry();
+    let revision = 2;
+    let page = 1;
+    surfaces.register({
+      descriptor: descriptor(),
+      getSnapshot: () => ({ revision, state: { page } }),
+      execute: (_command: DataSurfaceVisibleCommand) => {
+        page += 1;
+        revision += 1;
+      },
+    });
+    registerWebMcpUiTools({
+      controlRegistry: createControlInteractionRegistry(),
+      dataSurfaceRegistry: surfaces,
+      document: browser.document,
+    });
+    const list = findTool(browser.registered, 'smrt_ui_list_data_surfaces');
+    const inspect = findTool(
+      browser.registered,
+      'smrt_ui_inspect_data_surface',
+    );
+    const execute = findTool(
+      browser.registered,
+      'smrt_ui_execute_data_surface_control',
+    );
+    const identity = { surfaceId: 'content', kind: 'table' };
+
+    expect((await parse(list.execute({}))).result[0].columns).toHaveLength(1);
+    const snapshot = (await parse(inspect.execute({ identity }))).result;
+    expect(snapshot.descriptor.query.projectableColumnIds).toEqual(['id']);
+
+    const command = {
+      version: 1,
+      commandId: 'page-1',
+      identity,
+      expectedRevision: 2,
+      controlId: 'next-page',
+    };
+    expect((await parse(execute.execute(command))).result).toMatchObject({
+      ok: true,
+      revision: 3,
+    });
+    expect((await parse(execute.execute(command))).result).toMatchObject({
+      ok: true,
+      revision: 3,
+    });
+    expect(
+      (
+        await parse(
+          execute.execute({ ...command, controlId: 'different-control' }),
+        )
+      ).result,
+    ).toMatchObject({ ok: false, reason: 'idempotency_conflict' });
+    expect(
+      (await parse(execute.execute({ ...command, commandId: 'page-2' })))
+        .result,
+    ).toMatchObject({ ok: false, reason: 'stale_revision' });
+  });
+
+  it('rejects invalid and oversized requests with distinct failures', async () => {
+    const browser = modelContext();
+    const controls = createControlInteractionRegistry();
+    registerWebMcpUiTools({
+      controlRegistry: controls,
+      dataSurfaceRegistry: createDataSurfaceRegistry(),
+      document: browser.document,
+    });
+    const inspect = findTool(
+      browser.registered,
+      'smrt_ui_inspect_form_control',
+    );
+    expect(
+      await parse(
+        inspect.execute({ identity: { formId: '', controlId: 'name' } }),
+      ),
+    ).toEqual({
+      ok: false,
+      reason: 'invalid_identifier',
+      details: 'formId',
+    });
+    expect(
+      await parse(inspect.execute({ payload: 'x'.repeat(100_001) })),
+    ).toEqual({ ok: false, reason: 'limit_exceeded' });
+
+    controls.register({
+      identity: { formId: 'broken', controlId: 'value' },
+      metadata: { kind: 'text' },
+      getValue: () => {
+        throw new Error('private host detail');
+      },
+    });
+    const list = findTool(browser.registered, 'smrt_ui_list_form_controls');
+    const failed = await parse(list.execute({ formId: 'broken' }));
+    expect(failed).toEqual({ ok: false, reason: 'execution_failed' });
+    expect(JSON.stringify(failed)).not.toContain('private host detail');
+  });
+
+  it('locks a prefix atomically, permits distinct prefixes, and no-ops without WebMCP', () => {
+    const browser = modelContext();
+    const registries = {
+      controlRegistry: createControlInteractionRegistry(),
+      dataSurfaceRegistry: createDataSurfaceRegistry(),
+    };
+    const dispose = registerWebMcpUiTools({
+      ...registries,
+      document: browser.document,
+    });
+    expect(() =>
+      registerWebMcpUiTools({ ...registries, document: browser.document }),
+    ).toThrow('already registered');
+    expect(browser.registered).toHaveLength(6);
+
+    const disposeOther = registerWebMcpUiTools({
+      ...registries,
+      prefix: 'other_',
+      document: browser.document,
+    });
+    expect(browser.registered).toHaveLength(12);
+    disposeOther();
+    dispose();
+
+    expect(() =>
+      registerWebMcpUiTools({
+        ...registries,
+        document: {},
+      }),
+    ).not.toThrow();
+  });
+
+  it('aborts every partial registration and releases the lock when a host rejects a tool', () => {
+    const signals: AbortSignal[] = [];
+    let calls = 0;
+    const document = {
+      modelContext: {
+        registerTool(
+          _tool: WebMcpToolSpec,
+          options?: { signal?: AbortSignal },
+        ) {
+          calls += 1;
+          if (options?.signal) signals.push(options.signal);
+          if (calls === 3) throw new Error('host collision');
+        },
+      },
+    };
+    const registries = {
+      controlRegistry: createControlInteractionRegistry(),
+      dataSurfaceRegistry: createDataSurfaceRegistry(),
+    };
+
+    expect(() => registerWebMcpUiTools({ ...registries, document })).toThrow(
+      'host collision',
+    );
+    expect(signals.every((signal) => signal.aborted)).toBe(true);
+
+    calls = 0;
+    document.modelContext.registerTool = (
+      _tool: WebMcpToolSpec,
+      options?: { signal?: AbortSignal },
+    ) => {
+      calls += 1;
+      if (options?.signal) signals.push(options.signal);
+    };
+    expect(() =>
+      registerWebMcpUiTools({ ...registries, document }),
+    ).not.toThrow();
+    expect(calls).toBe(6);
+  });
+});

--- a/packages/smrt-svelte/src/web/__tests__/webmcp-ui.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/webmcp-ui.test.ts
@@ -3,7 +3,11 @@ import {
   type DataSurfaceDescriptor,
   type DataSurfaceVisibleCommand,
 } from '@happyvertical/smrt-ui/data';
-import { createControlInteractionRegistry } from '@happyvertical/smrt-ui/forms';
+import {
+  type ControlInteractionRegistry,
+  type ControlSnapshot,
+  createControlInteractionRegistry,
+} from '@happyvertical/smrt-ui/forms';
 import { describe, expect, it, vi } from 'vitest';
 import type { WebMcpToolSpec } from '../webmcp.svelte.js';
 import { registerWebMcpUiTools } from '../webmcp-ui.js';
@@ -241,6 +245,43 @@ describe('registerWebMcpUiTools', () => {
     expect(JSON.stringify(result)).not.toContain('customer 4711');
   });
 
+  it('redacts secret values from an injected registry even when its flags are inconsistent', async () => {
+    const browser = modelContext();
+    const snapshot = {
+      identity: { formId: 'injected', controlId: 'secret' },
+      metadata: { kind: 'password', sensitivity: 'secret' },
+      state: {
+        value: 'injected-secret-value',
+        valueRedacted: false,
+        stagedValue: 'injected-staged-secret',
+        stagedValueRedacted: false,
+      },
+    } satisfies ControlSnapshot;
+    const controls: ControlInteractionRegistry = {
+      register: () => () => {},
+      unregister: () => {},
+      list: () => [snapshot],
+      get: () => snapshot,
+      execute: async (command) => ({
+        ok: true,
+        action: command.action,
+        identity: command.identity,
+        snapshot,
+      }),
+      subscribe: () => () => {},
+    };
+    registerWebMcpUiTools({
+      controlRegistry: controls,
+      dataSurfaceRegistry: createDataSurfaceRegistry(),
+      document: browser.document,
+    });
+
+    const list = await parse(
+      findTool(browser.registered, 'smrt_ui_list_form_controls').execute({}),
+    );
+    expect(JSON.stringify(list)).not.toContain('injected-secret');
+  });
+
   it('filters hidden columns and preserves surface revision and replay failures', async () => {
     const browser = modelContext();
     const surfaces = createDataSurfaceRegistry();
@@ -260,6 +301,7 @@ describe('registerWebMcpUiTools', () => {
                 { columnId: 'internal', value: 'nested-hidden-filter' },
               ],
               sorting: [{ columnId: 'internal', direction: 'asc' }],
+              columnOrder: ['id', 'internal'],
             },
           },
         },
@@ -290,6 +332,7 @@ describe('registerWebMcpUiTools', () => {
     expect(snapshot.descriptor.query.projectableColumnIds).toEqual(['id']);
     expect(snapshot.state).not.toHaveProperty('internal');
     expect(JSON.stringify(snapshot)).not.toContain('nested-hidden-filter');
+    expect(snapshot.state.table.state.columnOrder).toEqual(['id']);
 
     const hiddenRowKeyDescriptor = descriptor();
     hiddenRowKeyDescriptor.rowKey = 'internal';

--- a/packages/smrt-svelte/src/web/__tests__/webmcp-ui.test.ts
+++ b/packages/smrt-svelte/src/web/__tests__/webmcp-ui.test.ts
@@ -154,7 +154,7 @@ describe('registerWebMcpUiTools', () => {
     expect(value).toBe('Ada');
   });
 
-  it('keeps secret values redacted from list and inspect responses', async () => {
+  it('keeps secret values redacted from list, inspect, and execute responses', async () => {
     const browser = modelContext();
     const controls = createControlInteractionRegistry();
     controls.register({
@@ -177,17 +177,28 @@ describe('registerWebMcpUiTools', () => {
       browser.registered,
       'smrt_ui_inspect_form_control',
     );
+    const execute = findTool(
+      browser.registered,
+      'smrt_ui_execute_form_control',
+    );
     const listed = await parse(list.execute({ formId: 'account' }));
     const inspected = await parse(
       inspect.execute({
         identity: { formId: 'account', controlId: 'password' },
       }),
     );
-    expect(JSON.stringify([listed, inspected])).not.toContain(
+    const executed = await parse(
+      execute.execute({
+        action: 'focus',
+        identity: { formId: 'account', controlId: 'password' },
+      }),
+    );
+    expect(JSON.stringify([listed, inspected, executed])).not.toContain(
       'never-serialize-this',
     );
     expect(listed.result[0].state.valueRedacted).toBe(true);
     expect(inspected.result.state.valueRedacted).toBe(true);
+    expect(executed.result.snapshot.state.valueRedacted).toBe(true);
   });
 
   it('filters hidden columns and preserves surface revision and replay failures', async () => {
@@ -222,6 +233,27 @@ describe('registerWebMcpUiTools', () => {
     expect((await parse(list.execute({}))).result[0].columns).toHaveLength(1);
     const snapshot = (await parse(inspect.execute({ identity }))).result;
     expect(snapshot.descriptor.query.projectableColumnIds).toEqual(['id']);
+
+    const hiddenRowKeyDescriptor = descriptor();
+    hiddenRowKeyDescriptor.rowKey = 'internal';
+    const hiddenRowKeySurfaces = createDataSurfaceRegistry();
+    hiddenRowKeySurfaces.register({
+      descriptor: hiddenRowKeyDescriptor,
+      getSnapshot: () => ({ revision: 0, state: {} }),
+    });
+    const hiddenRowKeyBrowser = modelContext();
+    registerWebMcpUiTools({
+      controlRegistry: createControlInteractionRegistry(),
+      dataSurfaceRegistry: hiddenRowKeySurfaces,
+      document: hiddenRowKeyBrowser.document,
+    });
+    const hiddenRowKeyList = await parse(
+      findTool(
+        hiddenRowKeyBrowser.registered,
+        'smrt_ui_list_data_surfaces',
+      ).execute({}),
+    );
+    expect(hiddenRowKeyList.result[0]).not.toHaveProperty('rowKey');
 
     const command = {
       version: 1,

--- a/packages/smrt-svelte/src/web/index.ts
+++ b/packages/smrt-svelte/src/web/index.ts
@@ -38,3 +38,15 @@ export {
   type UseUpdateAvailableOptions,
   useUpdateAvailable,
 } from './update-available.svelte.js';
+export type {
+  WebMcpProviderConfig,
+  WebMcpUiProviderConfig,
+} from './webmcp-provider.js';
+export {
+  type RegisterWebMcpUiToolsOptions,
+  registerWebMcpUiTools,
+} from './webmcp-ui.js';
+export {
+  useWebMcpUi,
+  type WebMcpUiContext,
+} from './webmcp-ui-context.js';

--- a/packages/smrt-svelte/src/web/webmcp-provider.ts
+++ b/packages/smrt-svelte/src/web/webmcp-provider.ts
@@ -1,0 +1,25 @@
+import type { DataSurfaceRegistry } from '@happyvertical/smrt-ui/data';
+import type { ControlInteractionRegistry } from '@happyvertical/smrt-ui/forms';
+import type {
+  RegisterWebMcpToolsOptions,
+  SmrtWebClient,
+  SmrtWebCollectionDefinition,
+} from '@happyvertical/smrt-web';
+
+export interface WebMcpUiProviderConfig {
+  controlRegistry?: ControlInteractionRegistry;
+  dataSurfaceRegistry?: DataSurfaceRegistry;
+  /** Document-global namespace prefix. @default 'smrt_ui_' */
+  prefix?: string;
+}
+
+export interface WebMcpProviderConfig {
+  definitions?: SmrtWebCollectionDefinition[];
+  client?: SmrtWebClient;
+  basePath?: string;
+  fetchFn?: typeof fetch;
+  scope?: string;
+  filter?: RegisterWebMcpToolsOptions['filter'];
+  /** Fixed browser-native tools over the mounted form/data registries. */
+  ui?: false | WebMcpUiProviderConfig;
+}

--- a/packages/smrt-svelte/src/web/webmcp-ui-context.ts
+++ b/packages/smrt-svelte/src/web/webmcp-ui-context.ts
@@ -1,0 +1,29 @@
+import type { DataSurfaceRegistry } from '@happyvertical/smrt-ui/data';
+import type { ControlInteractionRegistry } from '@happyvertical/smrt-ui/forms';
+import { getContext, setContext } from 'svelte';
+
+const WEBMCP_UI_CONTEXT_KEY = Symbol('smrt-webmcp-ui-context');
+
+export interface WebMcpUiContext {
+  readonly controlRegistry: ControlInteractionRegistry;
+  readonly dataSurfaceRegistry: DataSurfaceRegistry;
+}
+
+export function setWebMcpUiContext(context: WebMcpUiContext): void {
+  setContext(WEBMCP_UI_CONTEXT_KEY, context);
+}
+
+export function tryGetWebMcpUiContext(): WebMcpUiContext | null {
+  return getContext<WebMcpUiContext>(WEBMCP_UI_CONTEXT_KEY) ?? null;
+}
+
+/** Return the mounted-UI registries owned by the nearest SMRT Provider. */
+export function useWebMcpUi(): WebMcpUiContext {
+  const context = tryGetWebMcpUiContext();
+  if (!context) {
+    throw new Error(
+      'WebMCP UI context not found. Wrap this component with <Provider>.',
+    );
+  }
+  return context;
+}

--- a/packages/smrt-svelte/src/web/webmcp-ui-context.ts
+++ b/packages/smrt-svelte/src/web/webmcp-ui-context.ts
@@ -5,6 +5,7 @@ import { getContext, setContext } from 'svelte';
 const WEBMCP_UI_CONTEXT_KEY = Symbol('smrt-webmcp-ui-context');
 
 export interface WebMcpUiContext {
+  readonly enabled: boolean;
   readonly controlRegistry: ControlInteractionRegistry;
   readonly dataSurfaceRegistry: DataSurfaceRegistry;
 }
@@ -20,7 +21,7 @@ export function tryGetWebMcpUiContext(): WebMcpUiContext | null {
 /** Return the mounted-UI registries owned by the nearest SMRT Provider. */
 export function useWebMcpUi(): WebMcpUiContext {
   const context = tryGetWebMcpUiContext();
-  if (!context) {
+  if (!context?.enabled) {
     throw new Error(
       'WebMCP UI context not found. Wrap this component with <Provider>.',
     );

--- a/packages/smrt-svelte/src/web/webmcp-ui.ts
+++ b/packages/smrt-svelte/src/web/webmcp-ui.ts
@@ -170,16 +170,26 @@ function sanitizeControl(snapshot: ControlSnapshot): ControlSnapshot {
   };
 }
 
+type VisibleDataSurfaceDescriptor = Omit<DataSurfaceDescriptor, 'rowKey'> & {
+  rowKey?: string;
+};
+
+type VisibleDataSurfaceSnapshot = Omit<DataSurfaceSnapshot, 'descriptor'> & {
+  descriptor: VisibleDataSurfaceDescriptor;
+};
+
 function visibleDescriptor(
   descriptor: DataSurfaceDescriptor,
-): DataSurfaceDescriptor {
+): VisibleDataSurfaceDescriptor {
   const columns = descriptor.columns.filter(
     (column) => column.visibility !== 'hidden',
   );
   const visibleColumnIds = new Set(columns.map((column) => column.id));
+  const { rowKey, ...visible } = descriptor;
   return {
-    ...descriptor,
+    ...visible,
     identity: { ...descriptor.identity },
+    ...(visibleColumnIds.has(rowKey) ? { rowKey } : {}),
     columns,
     query: {
       ...descriptor.query,
@@ -202,7 +212,9 @@ function visibleDescriptor(
   };
 }
 
-function visibleSnapshot(snapshot: DataSurfaceSnapshot): DataSurfaceSnapshot {
+function visibleSnapshot(
+  snapshot: DataSurfaceSnapshot,
+): VisibleDataSurfaceSnapshot {
   return { ...snapshot, descriptor: visibleDescriptor(snapshot.descriptor) };
 }
 
@@ -350,7 +362,12 @@ function tools(
           } else {
             command = { action, identity } as ControlCommand;
           }
-          return controlRegistry.execute(command, { source: 'agent' });
+          const result = await controlRegistry.execute(command, {
+            source: 'agent',
+          });
+          return result.snapshot
+            ? { ...result, snapshot: sanitizeControl(result.snapshot) }
+            : result;
         }),
     },
     readTool(

--- a/packages/smrt-svelte/src/web/webmcp-ui.ts
+++ b/packages/smrt-svelte/src/web/webmcp-ui.ts
@@ -429,7 +429,10 @@ function tools(
             controlId: requiredIdentifier(input.controlId, 'controlId'),
             ...('payload' in input ? { payload: input.payload as never } : {}),
           };
-          return dataSurfaceRegistry.execute(command);
+          const result = await dataSurfaceRegistry.execute(command);
+          return result.snapshot
+            ? { ...result, snapshot: visibleSnapshot(result.snapshot) }
+            : result;
         }),
     },
   ];

--- a/packages/smrt-svelte/src/web/webmcp-ui.ts
+++ b/packages/smrt-svelte/src/web/webmcp-ui.ts
@@ -35,7 +35,29 @@ const PUBLIC_FAILURE_REASONS = new Set([
   'limit_exceeded',
   'not_found',
 ]);
+const PUBLIC_CONTROL_RESULT_REASONS = new Set([
+  'not_found',
+  'consent_required',
+  'sensitive_control',
+  'control_not_writable',
+  'control_not_editable',
+  'nothing_to_undo',
+  'denied',
+]);
 const documentLocks = new WeakMap<object, Set<string>>();
+
+class PublicToolError extends Error {
+  constructor(
+    readonly reason: string,
+    readonly details?: string,
+  ) {
+    super(reason);
+  }
+}
+
+function publicError(reason: string, details?: string): PublicToolError {
+  return new PublicToolError(reason, details);
+}
 
 export interface RegisterWebMcpUiToolsOptions {
   controlRegistry: ControlInteractionRegistry;
@@ -67,7 +89,7 @@ function requestBytes(value: unknown): number {
 
 function assertRequestSize(value: unknown): void {
   if (requestBytes(value) > DATA_SURFACE_MAX_REQUEST_BYTES) {
-    throw new RangeError('limit_exceeded');
+    throw publicError('limit_exceeded');
   }
 }
 
@@ -85,7 +107,7 @@ function requiredIdentifier(
       return code < 32 || code === 127;
     })
   ) {
-    throw new TypeError(`invalid_identifier:${name}`);
+    throw publicError('invalid_identifier', name);
   }
   return value;
 }
@@ -96,7 +118,7 @@ function optionalIdentifier(value: unknown, name: string): string | undefined {
 
 function record(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new TypeError('invalid_request');
+    throw publicError('invalid_request');
   }
   return value as Record<string, unknown>;
 }
@@ -128,7 +150,7 @@ function dataSurfaceIdentity(value: unknown): DataSurfaceIdentity {
   const input = record(value);
   const kind = input.kind;
   if (!['table', 'list', 'report', 'custom'].includes(String(kind))) {
-    throw new TypeError('invalid_request:identity.kind');
+    throw publicError('invalid_request', 'identity.kind');
   }
   const subjectInput = input.subject;
   const subject =
@@ -152,6 +174,10 @@ function dataSurfaceIdentity(value: unknown): DataSurfaceIdentity {
 }
 
 function sanitizeControl(snapshot: ControlSnapshot): ControlSnapshot {
+  const redactText =
+    snapshot.metadata.sensitivity === 'secret' || snapshot.state.valueRedacted;
+  const runtimeState = { ...snapshot.state };
+  delete runtimeState.validationMessage;
   return {
     ...snapshot,
     identity: { ...snapshot.identity },
@@ -163,11 +189,52 @@ function sanitizeControl(snapshot: ControlSnapshot): ControlSnapshot {
       options: snapshot.metadata.options?.map((option) => ({ ...option })),
     },
     state: {
-      ...snapshot.state,
+      ...(redactText ? runtimeState : snapshot.state),
       ...(snapshot.state.valueRedacted ? { value: undefined } : {}),
       ...(snapshot.state.stagedValueRedacted ? { stagedValue: undefined } : {}),
     },
   };
+}
+
+function sanitizeSurfaceValue(
+  value: unknown,
+  hiddenColumnIds: Set<string>,
+  redactRowIds: boolean,
+): unknown {
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) =>
+        sanitizeSurfaceValue(entry, hiddenColumnIds, redactRowIds),
+      )
+      .filter((entry) => entry !== undefined);
+  }
+  if (!value || typeof value !== 'object') return value;
+  const object = value as Record<string, unknown>;
+  if (
+    typeof object.columnId === 'string' &&
+    hiddenColumnIds.has(object.columnId)
+  ) {
+    return undefined;
+  }
+  return Object.fromEntries(
+    Object.entries(object).flatMap(([key, entry]) => {
+      if (hiddenColumnIds.has(key)) return [];
+      if (
+        redactRowIds &&
+        (key === 'selection' ||
+          key === 'selectedRowIds' ||
+          key === 'expandedRowIds')
+      ) {
+        return [];
+      }
+      const sanitized = sanitizeSurfaceValue(
+        entry,
+        hiddenColumnIds,
+        redactRowIds,
+      );
+      return sanitized === undefined ? [] : [[key, sanitized]];
+    }),
+  );
 }
 
 type VisibleDataSurfaceDescriptor = Omit<DataSurfaceDescriptor, 'rowKey'> & {
@@ -220,10 +287,12 @@ function visibleSnapshot(
       .filter((column) => column.visibility === 'hidden')
       .map((column) => column.id),
   );
-  const state = Object.fromEntries(
-    Object.entries(snapshot.state).filter(([key]) => !hiddenColumnIds.has(key)),
-  );
   const rowKeyHidden = hiddenColumnIds.has(snapshot.descriptor.rowKey);
+  const state = sanitizeSurfaceValue(
+    snapshot.state,
+    hiddenColumnIds,
+    rowKeyHidden,
+  ) as DataSurfaceSnapshot['state'];
   return {
     ...snapshot,
     descriptor: visibleDescriptor(snapshot.descriptor),
@@ -239,11 +308,9 @@ function executeSafely(
     .then(execute)
     .then(success)
     .catch((error: unknown) => {
-      const message =
-        error instanceof Error ? error.message : 'invalid_request';
-      const [reason, details] = message.split(':', 2);
-      return PUBLIC_FAILURE_REASONS.has(reason ?? '')
-        ? failure(reason as string, details)
+      return error instanceof PublicToolError &&
+        PUBLIC_FAILURE_REASONS.has(error.reason)
+        ? failure(error.reason, error.details)
         : failure('execution_failed');
     });
 }
@@ -322,7 +389,7 @@ function tools(
           assertRequestSize(args);
           const input = record(args);
           const snapshot = controlRegistry.get(controlIdentity(input.identity));
-          if (!snapshot) throw new Error('not_found');
+          if (!snapshot) throw publicError('not_found');
           return sanitizeControl(snapshot);
         }),
     ),
@@ -347,16 +414,16 @@ function tools(
           assertRequestSize(args);
           const input = record(args);
           if ('confirmed' in input)
-            throw new TypeError('invalid_request:confirmed');
+            throw publicError('invalid_request', 'confirmed');
           if (!CONTROL_ACTIONS.has(input.action as ControlCommandAction)) {
-            throw new TypeError('invalid_request:action');
+            throw publicError('invalid_request', 'action');
           }
           const action = input.action as ControlCommandAction;
           const identity = controlIdentity(input.identity);
           let command: ControlCommand;
           if (action === 'stage') {
             if (!('value' in input))
-              throw new TypeError('invalid_request:value');
+              throw publicError('invalid_request', 'value');
             command = { action, identity, value: input.value };
           } else if (action === 'apply') {
             command =
@@ -370,7 +437,7 @@ function tools(
                 input.durationMs < 0 ||
                 input.durationMs > 60_000)
             ) {
-              throw new TypeError('invalid_request:durationMs');
+              throw publicError('invalid_request', 'durationMs');
             }
             command = { action, identity, durationMs: input.durationMs };
           } else {
@@ -379,9 +446,18 @@ function tools(
           const result = await controlRegistry.execute(command, {
             source: 'agent',
           });
-          return result.snapshot
-            ? { ...result, snapshot: sanitizeControl(result.snapshot) }
-            : result;
+          const reason = result.reason
+            ? PUBLIC_CONTROL_RESULT_REASONS.has(result.reason)
+              ? result.reason
+              : 'execution_failed'
+            : undefined;
+          return {
+            ...result,
+            ...(reason ? { reason } : { reason: undefined }),
+            ...(result.snapshot
+              ? { snapshot: sanitizeControl(result.snapshot) }
+              : {}),
+          };
         }),
     },
     readTool(
@@ -411,7 +487,7 @@ function tools(
           const snapshot = dataSurfaceRegistry.inspect(
             dataSurfaceIdentity(input.identity),
           );
-          if (!snapshot) throw new Error('not_found');
+          if (!snapshot) throw publicError('not_found');
           return visibleSnapshot(snapshot);
         }),
     ),
@@ -444,13 +520,13 @@ function tools(
           assertRequestSize(args);
           const input = record(args);
           if (input.version !== 1)
-            throw new TypeError('invalid_request:version');
+            throw publicError('invalid_request', 'version');
           if (
             typeof input.expectedRevision !== 'number' ||
             !Number.isSafeInteger(input.expectedRevision) ||
             input.expectedRevision < 0
           ) {
-            throw new TypeError('invalid_request:expectedRevision');
+            throw publicError('invalid_request', 'expectedRevision');
           }
           const command: DataSurfaceVisibleCommand = {
             version: 1,

--- a/packages/smrt-svelte/src/web/webmcp-ui.ts
+++ b/packages/smrt-svelte/src/web/webmcp-ui.ts
@@ -190,8 +190,12 @@ function sanitizeControl(snapshot: ControlSnapshot): ControlSnapshot {
     },
     state: {
       ...(redactText ? runtimeState : snapshot.state),
-      ...(snapshot.state.valueRedacted ? { value: undefined } : {}),
-      ...(snapshot.state.stagedValueRedacted ? { stagedValue: undefined } : {}),
+      ...(redactText || snapshot.state.valueRedacted
+        ? { value: undefined }
+        : {}),
+      ...(redactText || snapshot.state.stagedValueRedacted
+        ? { stagedValue: undefined }
+        : {}),
     },
   };
 }
@@ -203,6 +207,9 @@ function sanitizeSurfaceValue(
 ): unknown {
   if (Array.isArray(value)) {
     return value
+      .filter(
+        (entry) => typeof entry !== 'string' || !hiddenColumnIds.has(entry),
+      )
       .map((entry) =>
         sanitizeSurfaceValue(entry, hiddenColumnIds, redactRowIds),
       )

--- a/packages/smrt-svelte/src/web/webmcp-ui.ts
+++ b/packages/smrt-svelte/src/web/webmcp-ui.ts
@@ -215,7 +215,19 @@ function visibleDescriptor(
 function visibleSnapshot(
   snapshot: DataSurfaceSnapshot,
 ): VisibleDataSurfaceSnapshot {
-  return { ...snapshot, descriptor: visibleDescriptor(snapshot.descriptor) };
+  const hiddenColumnIds = new Set(
+    snapshot.descriptor.columns
+      .filter((column) => column.visibility === 'hidden')
+      .map((column) => column.id),
+  );
+  const state = Object.fromEntries(
+    Object.entries(snapshot.state).filter(([key]) => !hiddenColumnIds.has(key)),
+  );
+  return {
+    ...snapshot,
+    descriptor: visibleDescriptor(snapshot.descriptor),
+    state,
+  };
 }
 
 function executeSafely(

--- a/packages/smrt-svelte/src/web/webmcp-ui.ts
+++ b/packages/smrt-svelte/src/web/webmcp-ui.ts
@@ -204,14 +204,18 @@ function sanitizeSurfaceValue(
   value: unknown,
   hiddenColumnIds: Set<string>,
   redactRowIds: boolean,
+  parentKey?: string,
 ): unknown {
   if (Array.isArray(value)) {
     return value
       .filter(
-        (entry) => typeof entry !== 'string' || !hiddenColumnIds.has(entry),
+        (entry) =>
+          parentKey !== 'columnOrder' ||
+          typeof entry !== 'string' ||
+          !hiddenColumnIds.has(entry),
       )
       .map((entry) =>
-        sanitizeSurfaceValue(entry, hiddenColumnIds, redactRowIds),
+        sanitizeSurfaceValue(entry, hiddenColumnIds, redactRowIds, parentKey),
       )
       .filter((entry) => entry !== undefined);
   }
@@ -238,6 +242,7 @@ function sanitizeSurfaceValue(
         entry,
         hiddenColumnIds,
         redactRowIds,
+        key,
       );
       return sanitized === undefined ? [] : [[key, sanitized]];
     }),

--- a/packages/smrt-svelte/src/web/webmcp-ui.ts
+++ b/packages/smrt-svelte/src/web/webmcp-ui.ts
@@ -1,0 +1,488 @@
+import {
+  DATA_SURFACE_IDENTIFIER_MAX_LENGTH,
+  DATA_SURFACE_MAX_REQUEST_BYTES,
+  type DataSurfaceDescriptor,
+  type DataSurfaceIdentity,
+  type DataSurfaceRegistry,
+  type DataSurfaceSnapshot,
+  type DataSurfaceVisibleCommand,
+} from '@happyvertical/smrt-ui/data';
+import type {
+  ControlCommand,
+  ControlCommandAction,
+  ControlIdentity,
+  ControlInteractionRegistry,
+  ControlSnapshot,
+} from '@happyvertical/smrt-ui/forms';
+import type { WebMcpToolSpec } from './webmcp.svelte.js';
+
+const CONTROL_ACTIONS = new Set<ControlCommandAction>([
+  'focus',
+  'reveal',
+  'highlight',
+  'explain',
+  'validate',
+  'stage',
+  'apply',
+  'clear',
+  'undo',
+]);
+const DEFAULT_PREFIX = 'smrt_ui_';
+const PREFIX_PATTERN = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
+const PUBLIC_FAILURE_REASONS = new Set([
+  'invalid_request',
+  'invalid_identifier',
+  'limit_exceeded',
+  'not_found',
+]);
+const documentLocks = new WeakMap<object, Set<string>>();
+
+export interface RegisterWebMcpUiToolsOptions {
+  controlRegistry: ControlInteractionRegistry;
+  dataSurfaceRegistry: DataSurfaceRegistry;
+  prefix?: string;
+  /** Injectable browser document used by tests and non-window hosts. */
+  document?: { modelContext?: WebMcpModelContext };
+}
+
+type ToolResult =
+  | { ok: true; result: unknown }
+  | { ok: false; reason: string; details?: string };
+
+function success(result: unknown): string {
+  return JSON.stringify({ ok: true, result } satisfies ToolResult);
+}
+
+function failure(reason: string, details?: string): string {
+  return JSON.stringify({
+    ok: false,
+    reason,
+    ...(details ? { details } : {}),
+  } satisfies ToolResult);
+}
+
+function requestBytes(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+}
+
+function assertRequestSize(value: unknown): void {
+  if (requestBytes(value) > DATA_SURFACE_MAX_REQUEST_BYTES) {
+    throw new RangeError('limit_exceeded');
+  }
+}
+
+function requiredIdentifier(
+  value: unknown,
+  name: string,
+  maxLength = DATA_SURFACE_IDENTIFIER_MAX_LENGTH,
+): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > maxLength ||
+    Array.from(value).some((character) => {
+      const code = character.charCodeAt(0);
+      return code < 32 || code === 127;
+    })
+  ) {
+    throw new TypeError(`invalid_identifier:${name}`);
+  }
+  return value;
+}
+
+function optionalIdentifier(value: unknown, name: string): string | undefined {
+  return value === undefined ? undefined : requiredIdentifier(value, name);
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError('invalid_request');
+  }
+  return value as Record<string, unknown>;
+}
+
+function controlIdentity(value: unknown): ControlIdentity {
+  const input = record(value);
+  const subjectInput = input.subject;
+  const subject =
+    subjectInput === undefined
+      ? undefined
+      : (() => {
+          const next = record(subjectInput);
+          return {
+            type: requiredIdentifier(next.type, 'subject.type'),
+            id: requiredIdentifier(next.id, 'subject.id'),
+            ...(next.label === undefined
+              ? {}
+              : { label: requiredIdentifier(next.label, 'subject.label') }),
+          };
+        })();
+  return {
+    formId: requiredIdentifier(input.formId, 'formId'),
+    controlId: requiredIdentifier(input.controlId, 'controlId'),
+    ...(subject ? { subject } : {}),
+  };
+}
+
+function dataSurfaceIdentity(value: unknown): DataSurfaceIdentity {
+  const input = record(value);
+  const kind = input.kind;
+  if (!['table', 'list', 'report', 'custom'].includes(String(kind))) {
+    throw new TypeError('invalid_request:identity.kind');
+  }
+  const subjectInput = input.subject;
+  const subject =
+    subjectInput === undefined
+      ? undefined
+      : (() => {
+          const next = record(subjectInput);
+          return {
+            type: requiredIdentifier(next.type, 'subject.type'),
+            id: requiredIdentifier(next.id, 'subject.id'),
+            ...(next.label === undefined
+              ? {}
+              : { label: requiredIdentifier(next.label, 'subject.label') }),
+          };
+        })();
+  return {
+    surfaceId: requiredIdentifier(input.surfaceId, 'surfaceId'),
+    kind: kind as DataSurfaceIdentity['kind'],
+    ...(subject ? { subject } : {}),
+  };
+}
+
+function sanitizeControl(snapshot: ControlSnapshot): ControlSnapshot {
+  return {
+    ...snapshot,
+    identity: { ...snapshot.identity },
+    metadata: {
+      ...snapshot.metadata,
+      constraints: snapshot.metadata.constraints
+        ? { ...snapshot.metadata.constraints }
+        : undefined,
+      options: snapshot.metadata.options?.map((option) => ({ ...option })),
+    },
+    state: {
+      ...snapshot.state,
+      ...(snapshot.state.valueRedacted ? { value: undefined } : {}),
+      ...(snapshot.state.stagedValueRedacted ? { stagedValue: undefined } : {}),
+    },
+  };
+}
+
+function visibleDescriptor(
+  descriptor: DataSurfaceDescriptor,
+): DataSurfaceDescriptor {
+  const columns = descriptor.columns.filter(
+    (column) => column.visibility !== 'hidden',
+  );
+  const visibleColumnIds = new Set(columns.map((column) => column.id));
+  return {
+    ...descriptor,
+    identity: { ...descriptor.identity },
+    columns,
+    query: {
+      ...descriptor.query,
+      projectableColumnIds: descriptor.query.projectableColumnIds.filter((id) =>
+        visibleColumnIds.has(id),
+      ),
+      searchableColumnIds: descriptor.query.searchableColumnIds?.filter((id) =>
+        visibleColumnIds.has(id),
+      ),
+      filterableColumnIds: descriptor.query.filterableColumnIds?.filter((id) =>
+        visibleColumnIds.has(id),
+      ),
+      sortableColumnIds: descriptor.query.sortableColumnIds?.filter((id) =>
+        visibleColumnIds.has(id),
+      ),
+    },
+    actions: descriptor.actions.filter((action) =>
+      (action.columnIds ?? []).every((id) => visibleColumnIds.has(id)),
+    ),
+  };
+}
+
+function visibleSnapshot(snapshot: DataSurfaceSnapshot): DataSurfaceSnapshot {
+  return { ...snapshot, descriptor: visibleDescriptor(snapshot.descriptor) };
+}
+
+function executeSafely(
+  execute: () => unknown | Promise<unknown>,
+): Promise<string> {
+  return Promise.resolve()
+    .then(execute)
+    .then(success)
+    .catch((error: unknown) => {
+      const message =
+        error instanceof Error ? error.message : 'invalid_request';
+      const [reason, details] = message.split(':', 2);
+      return PUBLIC_FAILURE_REASONS.has(reason ?? '')
+        ? failure(reason as string, details)
+        : failure('execution_failed');
+    });
+}
+
+function readTool(
+  name: string,
+  description: string,
+  inputSchema: Record<string, unknown>,
+  execute: WebMcpToolSpec['execute'],
+): WebMcpToolSpec {
+  return {
+    name,
+    description,
+    inputSchema,
+    annotations: { readOnlyHint: true, untrustedContentHint: true },
+    execute,
+  };
+}
+
+function tools(
+  prefix: string,
+  controlRegistry: ControlInteractionRegistry,
+  dataSurfaceRegistry: DataSurfaceRegistry,
+): WebMcpToolSpec[] {
+  const identitySchema = {
+    type: 'object',
+    required: ['formId', 'controlId'],
+    additionalProperties: false,
+    properties: {
+      formId: { type: 'string', minLength: 1, maxLength: 256 },
+      controlId: { type: 'string', minLength: 1, maxLength: 256 },
+      subject: { type: 'object' },
+    },
+  };
+  const surfaceIdentitySchema = {
+    type: 'object',
+    required: ['surfaceId', 'kind'],
+    additionalProperties: false,
+    properties: {
+      surfaceId: { type: 'string', minLength: 1, maxLength: 256 },
+      kind: { type: 'string', enum: ['table', 'list', 'report', 'custom'] },
+      subject: { type: 'object' },
+    },
+  };
+
+  return [
+    readTool(
+      `${prefix}list_form_controls`,
+      'List the controls currently mounted in SMRT forms.',
+      {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          formId: { type: 'string', minLength: 1, maxLength: 256 },
+        },
+      },
+      (args) =>
+        executeSafely(() => {
+          assertRequestSize(args);
+          const input = record(args);
+          const formId = optionalIdentifier(input.formId, 'formId');
+          return controlRegistry.list(formId).map(sanitizeControl);
+        }),
+    ),
+    readTool(
+      `${prefix}inspect_form_control`,
+      'Inspect one currently mounted SMRT form control.',
+      {
+        type: 'object',
+        required: ['identity'],
+        additionalProperties: false,
+        properties: { identity: identitySchema },
+      },
+      (args) =>
+        executeSafely(() => {
+          assertRequestSize(args);
+          const input = record(args);
+          const snapshot = controlRegistry.get(controlIdentity(input.identity));
+          if (!snapshot) throw new Error('not_found');
+          return sanitizeControl(snapshot);
+        }),
+    ),
+    {
+      name: `${prefix}execute_form_control`,
+      description:
+        'Execute an allowed command on a mounted SMRT form control. Agent mutations are consent-gated.',
+      inputSchema: {
+        type: 'object',
+        required: ['action', 'identity'],
+        additionalProperties: false,
+        properties: {
+          action: { type: 'string', enum: [...CONTROL_ACTIONS] },
+          identity: identitySchema,
+          value: {},
+          durationMs: { type: 'number', minimum: 0, maximum: 60_000 },
+        },
+      },
+      annotations: { readOnlyHint: false, untrustedContentHint: true },
+      execute: (args) =>
+        executeSafely(async () => {
+          assertRequestSize(args);
+          const input = record(args);
+          if ('confirmed' in input)
+            throw new TypeError('invalid_request:confirmed');
+          if (!CONTROL_ACTIONS.has(input.action as ControlCommandAction)) {
+            throw new TypeError('invalid_request:action');
+          }
+          const action = input.action as ControlCommandAction;
+          const identity = controlIdentity(input.identity);
+          let command: ControlCommand;
+          if (action === 'stage') {
+            if (!('value' in input))
+              throw new TypeError('invalid_request:value');
+            command = { action, identity, value: input.value };
+          } else if (action === 'apply') {
+            command =
+              'value' in input
+                ? { action, identity, value: input.value }
+                : { action, identity };
+          } else if (action === 'highlight') {
+            if (
+              input.durationMs !== undefined &&
+              (typeof input.durationMs !== 'number' ||
+                input.durationMs < 0 ||
+                input.durationMs > 60_000)
+            ) {
+              throw new TypeError('invalid_request:durationMs');
+            }
+            command = { action, identity, durationMs: input.durationMs };
+          } else {
+            command = { action, identity } as ControlCommand;
+          }
+          return controlRegistry.execute(command, { source: 'agent' });
+        }),
+    },
+    readTool(
+      `${prefix}list_data_surfaces`,
+      'List the data surfaces currently mounted in this SMRT Provider.',
+      { type: 'object', additionalProperties: false, properties: {} },
+      (args) =>
+        executeSafely(() => {
+          assertRequestSize(args);
+          record(args);
+          return dataSurfaceRegistry.list().map(visibleDescriptor);
+        }),
+    ),
+    readTool(
+      `${prefix}inspect_data_surface`,
+      'Inspect one currently mounted SMRT data surface.',
+      {
+        type: 'object',
+        required: ['identity'],
+        additionalProperties: false,
+        properties: { identity: surfaceIdentitySchema },
+      },
+      (args) =>
+        executeSafely(() => {
+          assertRequestSize(args);
+          const input = record(args);
+          const snapshot = dataSurfaceRegistry.inspect(
+            dataSurfaceIdentity(input.identity),
+          );
+          if (!snapshot) throw new Error('not_found');
+          return visibleSnapshot(snapshot);
+        }),
+    ),
+    {
+      name: `${prefix}execute_data_surface_control`,
+      description:
+        'Execute a bounded visible-state command on a mounted SMRT data surface.',
+      inputSchema: {
+        type: 'object',
+        required: [
+          'version',
+          'commandId',
+          'identity',
+          'expectedRevision',
+          'controlId',
+        ],
+        additionalProperties: false,
+        properties: {
+          version: { type: 'number', const: 1 },
+          commandId: { type: 'string', minLength: 1, maxLength: 256 },
+          identity: surfaceIdentitySchema,
+          expectedRevision: { type: 'number', minimum: 0 },
+          controlId: { type: 'string', minLength: 1, maxLength: 256 },
+          payload: {},
+        },
+      },
+      annotations: { readOnlyHint: false, untrustedContentHint: true },
+      execute: (args) =>
+        executeSafely(async () => {
+          assertRequestSize(args);
+          const input = record(args);
+          if (input.version !== 1)
+            throw new TypeError('invalid_request:version');
+          if (
+            typeof input.expectedRevision !== 'number' ||
+            !Number.isSafeInteger(input.expectedRevision) ||
+            input.expectedRevision < 0
+          ) {
+            throw new TypeError('invalid_request:expectedRevision');
+          }
+          const command: DataSurfaceVisibleCommand = {
+            version: 1,
+            commandId: requiredIdentifier(input.commandId, 'commandId'),
+            identity: dataSurfaceIdentity(input.identity),
+            expectedRevision: input.expectedRevision,
+            controlId: requiredIdentifier(input.controlId, 'controlId'),
+            ...('payload' in input ? { payload: input.payload as never } : {}),
+          };
+          return dataSurfaceRegistry.execute(command);
+        }),
+    },
+  ];
+}
+
+/** Register the fixed browser-native adapter over mounted UI registries. */
+export function registerWebMcpUiTools(
+  options: RegisterWebMcpUiToolsOptions,
+): () => void {
+  const prefix = options.prefix ?? DEFAULT_PREFIX;
+  if (!PREFIX_PATTERN.test(prefix)) {
+    throw new TypeError('Invalid WebMCP UI tool prefix');
+  }
+
+  const documentLike =
+    options.document ??
+    (globalThis as { document?: { modelContext?: WebMcpModelContext } })
+      .document;
+  const modelContext = documentLike?.modelContext;
+  if (!modelContext || typeof modelContext.registerTool !== 'function') {
+    return () => {};
+  }
+
+  let locks = documentLocks.get(documentLike);
+  if (!locks) {
+    locks = new Set();
+    documentLocks.set(documentLike, locks);
+  }
+  if (locks.has(prefix)) {
+    throw new Error(`WebMCP UI prefix is already registered: ${prefix}`);
+  }
+  locks.add(prefix);
+
+  const controller = new AbortController();
+  let disposed = false;
+  try {
+    for (const tool of tools(
+      prefix,
+      options.controlRegistry,
+      options.dataSurfaceRegistry,
+    )) {
+      modelContext.registerTool(tool, { signal: controller.signal });
+    }
+  } catch (error) {
+    controller.abort();
+    locks.delete(prefix);
+    throw error;
+  }
+
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    controller.abort();
+    locks.delete(prefix);
+  };
+}

--- a/packages/smrt-svelte/src/web/webmcp-ui.ts
+++ b/packages/smrt-svelte/src/web/webmcp-ui.ts
@@ -223,10 +223,12 @@ function visibleSnapshot(
   const state = Object.fromEntries(
     Object.entries(snapshot.state).filter(([key]) => !hiddenColumnIds.has(key)),
   );
+  const rowKeyHidden = hiddenColumnIds.has(snapshot.descriptor.rowKey);
   return {
     ...snapshot,
     descriptor: visibleDescriptor(snapshot.descriptor),
     state,
+    selection: rowKeyHidden ? null : snapshot.selection,
   };
 }
 


### PR DESCRIPTION
## Summary

- expose mounted SMRT form controls and data surfaces through exactly six fixed WebMCP tools
- aggregate UI registries through explicit Provider opt-in while preserving bespoke Form/useWebMcpTool behavior
- enforce consent, namespace, lifecycle, error-sanitization, and recursive redaction boundaries
- retry mounted form controls after duplicate registry identities are removed

## Validation

- npm run build — 64/64 tasks
- pnpm --filter @happyvertical/smrt-svelte test — 62 files, 591 tests
- pnpm --filter @happyvertical/smrt-svelte typecheck — 0 Svelte errors/warnings
- pnpm --filter @happyvertical/smrt-svelte verify:pack — exports verified
- strict knowledge freshness — 0 issues
- pre-push policy suite — green
- independent Terra/Sonnet and Sol/Fable security/lifecycle review cycles completed

Closes #2521

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-webmcp-2521-review-20260826","issue":2521,"policy_revision":"1.0.0","status":"complete","validation":["workspace build","smrt-svelte tests","smrt-svelte typecheck","smrt-svelte pack verification","strict knowledge freshness","independent exact-head review"]}
